### PR TITLE
[CIVP-10256] Default matplotlib to "Agg" backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
+## [1.0.1] - 2017-02-13
+### Changed
+- Add environment variables which record the image version number (#1)
+
+### Fixed
+- Add `matplotlibrc` file which changes the backend default to "Agg" (#3)
+
 ## [1.0.0] - 2017-01-17
 
 * Initial Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,13 @@ RUN conda install -y boto && \
     conda install -y nomkl && \
     conda env create -f environment.yml
 
+# We aren't running a GUI, so force matplotlib to use
+# the non-interactive "Agg" backend for graphics.
+RUN echo "backend      : Agg" > matplotlibrc
+
+# Run matplotlib once to build the font cache
+RUN python -c "import matplotlib.pyplot"
+
 ENV VERSION=1.0.1\
     VERSION_MAJOR=1\
     VERSION_MINOR=0\

--- a/circle.yml
+++ b/circle.yml
@@ -10,4 +10,5 @@ test:
     override:
         - docker run civisanalytics/datascience-python /bin/bash -c "echo BUILDS OK"
         - docker run civisanalytics/datascience-python python -c "from scipy.linalg import _fblas"
-        - docker run civisanalytics/datascience-python python -c "import numpy, matplotlib, os; matplotlib.use('Agg'); import matplotlib.pyplot as plt; x = numpy.arange(100); y = numpy.sin(x); plt.plot(x, y);"
+        - docker run civisanalytics/datascience-python python -c "import numpy, os; import matplotlib.pyplot as plt; x = numpy.arange(100); y = numpy.sin(x); plt.plot(x, y);"
+        - docker run civisanalytics/datascience-python python -c "import seaborn"


### PR DESCRIPTION
`matplotlib`'s default Qt backend fails in the container. We're not running a GUI, so set the non-interactive "Agg" backend as the default.

See also http://matplotlib.org/faq/usage_faq.html#what-is-a-backend .