### PR TITLE
Change from bash.bashrc to profile for noninteractive sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
-## [1.1.1] - 2017-02-09
-### Fixed
-- Add `source activate datascience` to `etc/profile` to ensure bash enjoys the datascience environment (#4)
-
 ## [1.1.0] - 2017-02-10
 ### Changed
 - Add environment variables which record the image version number (#1)
@@ -18,6 +14,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ### Fixed
 - Add `matplotlibrc` file which changes the backend default to "Agg" (#3)
+- Add `source activate datascience` to `etc/profile` to ensure bash enjoys the datascience environment (#4)
 
 ## [1.0.0] - 2017-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## [1.1.0] - 2017-02-10
 ### Changed
+- Add `source activate datascience` to `etc/profile` to ensure bash enjoys the datascience environment (#4)
+
+## [1.1.0] - 2017-02-10
+### Changed
 - Add environment variables which record the image version number (#1)
 - Upgraded civis library from v1.1.0 to v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
-## [1.1.0] - 2017-02-10
-### Changed
+## [1.1.1] - 2017-02-09
+### Fixed
 - Add `source activate datascience` to `etc/profile` to ensure bash enjoys the datascience environment (#4)
 
 ## [1.1.0] - 2017-02-10

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     /opt/conda/bin/conda install --yes conda==4.1.11
 
 # environment for bash
-RUN echo "source activate datascience" >> /etc/bash.bashrc
+RUN echo "source activate datascience" >> /etc/profile
 
 # Red Hat and Debian use different names for this file. git2R wants the latter.
 # See conda-recipes GH 423

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     /opt/conda/bin/conda install --yes conda==4.1.11
 
 # environment for bash
-RUN echo "source activate datascience" >> /etc/profile
+RUN echo "source activate datascience" >> /etc/profile && \
+    echo "source activate datascience" >> /etc/bash.bashrc
 
 # Red Hat and Debian use different names for this file. git2R wants the latter.
 # See conda-recipes GH 423

--- a/circle.yml
+++ b/circle.yml
@@ -12,4 +12,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "from scipy.linalg import _fblas"
         - docker run civisanalytics/datascience-python python -c "import numpy, os; import matplotlib.pyplot as plt; x = numpy.arange(100); y = numpy.sin(x); plt.plot(x, y);"
         - docker run civisanalytics/datascience-python python -c "import seaborn"
-	- docker run -t civisanalytics/datascience-python /bin/bash -c "python -c 'import numpy'"
+        - docker run -t civisanalytics/datascience-python /bin/bash -c "python -c 'import numpy'"

--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "from scipy.linalg import _fblas"
         - docker run civisanalytics/datascience-python python -c "import numpy, os; import matplotlib.pyplot as plt; x = numpy.arange(100); y = numpy.sin(x); plt.plot(x, y);"
         - docker run civisanalytics/datascience-python python -c "import seaborn"
+	- docker run -t civisanalytics/datascience-python /bin/bash -c "python -c 'import numpy'"


### PR DESCRIPTION
This PR changes the activation of the datascience conda environment (as in `source activate datascience`) from `/etc/bash.bashrc` to `/etc/profile`. 

I'm not sure of the full range of the implications of this change. As things stand now, however, the following command fails:
```
docker run -t civisanalytics/datascience-python /bin/bash -c "python -c 'import numpy'"
```
The error is `ImportError: No module named 'numpy'`. This PR causes the above command to succeed. 

I think this is happening because `/bin/bash -c command` is a noninteractive shell, and `/etc/bash.bashrc` is used for interactive shells; so the datascience environment isn't available. See [this](http://askubuntu.com/questions/247738/why-is-etc-profile-not-invoked-for-non-login-shells) for context.

Running simply 
```
docker run -t civisanalytics/datascience-python python -c 'import numpy'
```
works regardless of the where the datascience environment is activated, because this implicitly calls `/bin/sh -c 'python -c "import numpy"'` instead of `/bin/bash`.  

However, oftentimes we wish to use `/bin/bash -c command`. Since this is noninteractive, we have two options: put `source activate datascience` in a profile (like this PR), or put it _before_ the following lines in `/etc/bash.bashrc` (instead of after like in the Dockerfile):
```
# If not running interactively, don't do anything
[ -z "$PS1" ] && return
```

