### PR TITLE
[CIVP-10269] make sure matplotlib can always find the matplotlibrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
+### Fixed
+- Changed location of `matplotlibrc` to always be found (#6)
+
 ## [1.1.0] - 2017-02-10
 ### Changed
 - Add environment variables which record the image version number (#1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,13 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
-### Fixed
-- Changed location of `matplotlibrc` to always be found (#6)
-
 ## [1.1.0] - 2017-02-10
 ### Changed
 - Add environment variables which record the image version number (#1)
 - Upgraded civis library from v1.1.0 to v1.2.0
 
 ### Fixed
+- Changed location of `matplotlibrc` to always be found (#6)
 - Add `matplotlibrc` file which changes the backend default to "Agg" (#3)
 
 ## [1.0.0] - 2017-01-17

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,9 @@ RUN conda install -y boto && \
 
 # We aren't running a GUI, so force matplotlib to use
 # the non-interactive "Agg" backend for graphics.
-ENV MATPLOTLIBRC=/opt/matplotlibrc/matplotlibrc
-RUN mkdir -p /opt/matplotlibrc/
-RUN echo "backend      : Agg" > /opt/matplotlibrc/matplotlibrc
+ENV MATPLOTLIBRC=${HOME}/.config/matplotlib/matplotlibrc
+RUN mkdir -p ${HOME}/.config/matplotlib
+RUN echo "backend      : Agg" > ${HOME}/.config/matplotlib/matplotlibrc
 
 # Run matplotlib once to build the font cache
 RUN python -c "import matplotlib.pyplot"

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,9 @@ RUN conda install -y boto && \
 
 # We aren't running a GUI, so force matplotlib to use
 # the non-interactive "Agg" backend for graphics.
-RUN echo "backend      : Agg" > matplotlibrc
+ENV MATPLOTLIBRC=/opt/matplotlibrc/matplotlibrc
+RUN mkdir -p ${MATPLOTLIBRC}
+RUN echo "backend      : Agg" > /opt/matplotlibrc/matplotlibrc
 
 # Run matplotlib once to build the font cache
 RUN python -c "import matplotlib.pyplot"

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN conda install -y boto && \
 # We aren't running a GUI, so force matplotlib to use
 # the non-interactive "Agg" backend for graphics.
 ENV MATPLOTLIBRC=/opt/matplotlibrc/matplotlibrc
-RUN mkdir -p ${MATPLOTLIBRC}
+RUN mkdir -p /opt/matplotlibrc/
 RUN echo "backend      : Agg" > /opt/matplotlibrc/matplotlibrc
 
 # Run matplotlib once to build the font cache


### PR DESCRIPTION
I don't know the best spot to put this, so I chose `/opt/matplitlibrc/matplotlibrc`. There may be a better way. 