### PR TITLE
PROD Increase version to 1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN echo "backend      : Agg" > matplotlibrc
 # Run matplotlib once to build the font cache
 RUN python -c "import matplotlib.pyplot"
 
-ENV VERSION=1.0.1\
+ENV VERSION=1.1.0\
     VERSION_MAJOR=1\
-    VERSION_MINOR=0\
-    VERSION_MICRO=1
+    VERSION_MINOR=1\
+    VERSION_MICRO=0


### PR DESCRIPTION
We're bumping the Civis API client by a minor version with the next release, so the container increases by a minor version too.