### PR TITLE
ENH upgrade conda to 4.3.11 and python to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 ### Changed
 - Moved conda to version 4.3.11 (#11)
 - Moved python to version 3.6.0 (#11)
-- Various package version changes
+- Various package version changes (#11)
     - boto 2.45.0
     - cython 0.25.2
     - jinja2 2.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Version number changes (major.minor.micro) in this package denote the following:
     - boto 2.45.0
     - cython 0.25.2
     - jinja2 2.8
-    - joblib 0.9.4
+    - joblib 0.10.3
     - pyyaml 3.12
     - requests=2.12.4    
 - Moved conda to version 4.2.12 (#8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## [2.0.0]
 ### Changed
+- Moved conda to version 4.3.11 (#11)
+- Moved python to version 3.6.0 (#11)
 - Moved conda to version 4.2.12 (#8)
 - Moved package install from the `datascience` environment to `root` (#8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Version number changes (major.minor.micro) in this package denote the following:
 ### Changed
 - Moved conda to version 4.3.11 (#11)
 - Moved python to version 3.6.0 (#11)
+- Various package version changes
+    - boto 2.45.0
+    - cython 0.25.2
+    - jinja2 2.8
+    - joblib 0.9.4
+    - pyyaml 3.12
+    - requests=2.12.4    
 - Moved conda to version 4.2.12 (#8)
 - Moved package install from the `datascience` environment to `root` (#8)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     CONDARC=/opt/conda/.condarc \
     BASH_ENV=/etc/profile \
-    PATH=/opt/conda/bin:$PATH
+    PATH=/opt/conda/bin:$PATH \
+    OUR_CONDA_VERSION=4.3.11 \
+    OUR_PYTHON_VERSION=3.5.2
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
   apt-get install -y software-properties-common && \
@@ -30,11 +32,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
       curl
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh && \
-    /bin/bash /Miniconda3-4.2.12-Linux-x86_64.sh -b -p /opt/conda && \
-    rm Miniconda3-4.2.12-Linux-x86_64.sh && \
-    /opt/conda/bin/conda install --yes conda==4.2.12 && \
-    echo "conda ==4.2.12" > /opt/conda/conda-meta/pinned
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${OUR_CONDA_VERSION}-Linux-x86_64.sh && \
+    /bin/bash /Miniconda3-${OUR_CONDA_VERSION}-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniconda3-${OUR_CONDA_VERSION}-Linux-x86_64.sh && \
+    /opt/conda/bin/conda install --yes conda==${OUR_CONDA_VERSION} && \
+    echo "conda ==${OUR_CONDA_VERSION}" > /opt/conda/conda-meta/pinned && \
+    conda install python==${OUR_PYTHON_VERSION} && \
+    echo "\npython ==${OUR_PYTHON_VERSION}" >> /opt/conda/conda-meta/pinned
 
 # Red Hat and Debian use different names for this file. git2R wants the latter.
 # See conda-recipes GH 423

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV LANG=en_US.UTF-8 \
     CONDARC=/opt/conda/.condarc \
     BASH_ENV=/etc/profile \
     PATH=/opt/conda/bin:$PATH \
-    OUR_CONDA_VERSION=4.3.11 \
-    OUR_PYTHON_VERSION=3.5.2
+    CIVIS_CONDA_VERSION=4.3.11 \
+    CIVIS_PYTHON_VERSION=3.6.0
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
   apt-get install -y software-properties-common && \
@@ -32,13 +32,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && \
       curl
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${OUR_CONDA_VERSION}-Linux-x86_64.sh && \
-    /bin/bash /Miniconda3-${OUR_CONDA_VERSION}-Linux-x86_64.sh -b -p /opt/conda && \
-    rm Miniconda3-${OUR_CONDA_VERSION}-Linux-x86_64.sh && \
-    /opt/conda/bin/conda install --yes conda==${OUR_CONDA_VERSION} && \
-    echo "conda ==${OUR_CONDA_VERSION}" > /opt/conda/conda-meta/pinned && \
-    conda install python==${OUR_PYTHON_VERSION} && \
-    echo "\npython ==${OUR_PYTHON_VERSION}" >> /opt/conda/conda-meta/pinned
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${CIVIS_CONDA_VERSION}-Linux-x86_64.sh && \
+    /bin/bash /Miniconda3-${CIVIS_CONDA_VERSION}-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniconda3-${CIVIS_CONDA_VERSION}-Linux-x86_64.sh && \
+    /opt/conda/bin/conda install --yes conda==${CIVIS_CONDA_VERSION} && \
+    echo "conda ==${CIVIS_CONDA_VERSION}" > /opt/conda/conda-meta/pinned && \
+    conda install python==${CIVIS_PYTHON_VERSION} && \
+    echo "\npython ==${CIVIS_PYTHON_VERSION}" >> /opt/conda/conda-meta/pinned
 
 # Red Hat and Debian use different names for this file. git2R wants the latter.
 # See conda-recipes GH 423

--- a/circle.yml
+++ b/circle.yml
@@ -13,3 +13,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "import numpy, os; import matplotlib.pyplot as plt; x = numpy.arange(100); y = numpy.sin(x); plt.plot(x, y);"
         - docker run civisanalytics/datascience-python python -c "import seaborn"
         - docker run -t civisanalytics/datascience-python /bin/bash -c "python -c 'import numpy'"
+        - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
 - pytest=3.0.5
 - python=3.5.2
 - pyyaml=3.11
-- requests=2.12.1
+- requests=2.12.4
 - seaborn=0.7.1
 - scipy=0.18.1
 - scikit-learn=0.18.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - cython=0.25.2
 - ipython=5.1.0
 - jinja2=2.8
-- joblib=0.9.4
+- joblib=0.10.3
 - jsonschema=2.5.1
 - jupyter=1.0.0
 - libffi=3.2.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,8 @@
 name: root
 dependencies:
 - beautifulsoup4=4.5.1
-- boto=2.43.0
-- cython=0.25.1
+- boto=2.45.0
+- cython=0.25.2
 - ipython=5.1.0
 - jinja2=2.8
 - joblib=0.9.4
@@ -26,8 +26,8 @@ dependencies:
 - psycopg2=2.6.2
 - pycrypto=2.6.1
 - pytest=3.0.5
-- python=3.5.2
-- pyyaml=3.11
+- python=3.6.0
+- pyyaml=3.12
 - requests=2.12.4
 - seaborn=0.7.1
 - scipy=0.18.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ dependencies:
 - cython=0.25.2
 - ipython=5.1.0
 - jinja2=2.8
-- joblib=0.10.3
 - jsonschema=2.5.1
 - jupyter=1.0.0
 - libffi=3.2.1
@@ -39,6 +38,7 @@ dependencies:
   - civis==1.2.0
   - dropbox==7.1.1
   - ftputil==3.3.1
+  - joblib==0.10.3
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
   - urllib3==1.19

--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,10 @@ dependencies:
 - boto=2.43.0
 - cython=0.25.1
 - ipython=5.1.0
+- jinja2=2.8
+- joblib=0.9.4
 - jsonschema=2.5.1
 - jupyter=1.0.0
-- jinja2=2.8
 - libffi=3.2.1
 - libgcc=5.2.0
 - libgfortran=3.0.0


### PR DESCRIPTION
A general update of conda and python to newest version, along with installing some dependencies by hand.