### PR TITLE
ENH Upgrade to newest compatible versions of all packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,25 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
 ## [2.0.0]
+### Added
+- joblib 0.10.3 (#11)
+
 ### Changed
 - Moved conda to version 4.3.11 (#11)
 - Moved python to version 3.6.0 (#11)
-- Various package version changes (#11)
-    - boto 2.45.0
-    - cython 0.25.2
-    - jinja2 2.8
-    - joblib 0.10.3
-    - pyyaml 3.12
-    - requests=2.12.4    
-- Moved conda to version 4.2.12 (#8)
+- Various package version changes (#11, #13)
+    - beautifulsoup4 4.5.1 --> 4.5.3
+    - boto 2.43.0 --> 2.45.0
+    - boto3 1.4.2 --> 1.4.3
+    - cython 0.25.1 --> 0.25.2
+    - matplotlib 1.5.3 --> 2.0.0
+    - nltk 3.2.1 --> 3.2.2
+    - numexpr 2.6.1 --> 2.6.2
+    - numpy 1.11.3 --> 1.12.0
+    - pandas 0.19.1 --> 0.19.2
+    - pyyaml 3.11 --> 3.12
+    - requests 2.12.1 --> 2.12.4
+    - statsmodels 0.6.1 --> 0.8.0
 - Moved package install from the `datascience` environment to `root` (#8)
 
 ## [1.1.0] - 2017-02-13

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,8 @@
 name: root
 dependencies:
-- beautifulsoup4=4.5.1
+- beautifulsoup4=4.5.3
 - boto=2.45.0
+- boto3==1.4.3
 - cython=0.25.2
 - ipython=5.1.0
 - jinja2=2.8
@@ -13,14 +14,14 @@ dependencies:
 - libsodium=1.0.10
 - libtiff=4.0.6
 - libxml2=2.9.2
-- matplotlib=1.5.3
+- matplotlib=2.0.0
 - nomkl=1.0
 - nose=1.3.7
-- nltk=3.2.1
-- numexpr=2.6.1
-- numpy=1.11.3
+- nltk=3.2.2
+- numexpr=2.6.2
+- numpy=1.12.0
 - openblas=0.2.19
-- pandas=0.19.1
+- pandas=0.19.2
 - patsy=0.4.1
 - psycopg2=2.6.2
 - pycrypto=2.6.1
@@ -31,10 +32,9 @@ dependencies:
 - seaborn=0.7.1
 - scipy=0.18.1
 - scikit-learn=0.18.1
-- statsmodels=0.6.1
+- statsmodels=0.8.0
 - pip:
   - awscli==1.11.27
-  - boto3==1.4.2
   - civis==1.2.0
   - dropbox==7.1.1
   - ftputil==3.3.1


### PR DESCRIPTION
Keep us current on all the package versions that we use.

Major version change:
    - matplotlib 1.5.3 --> 2.0.0

Minor version change:
    - numpy 1.11.3 --> 1.12.0
    - statsmodels 0.6.1 --> 0.8.0

Micro version change:
    - beautifulsoup4 4.5.1 --> 4.5.3
    - boto3 1.4.2 --> 1.4.3 (also move from pip to conda install)
    - nltk 3.2.1 --> 3.2.2
    - numexpr 2.6.1 --> 2.6.2
    - pandas 0.19.1 --> 0.19.2