### PR TITLE
ENH Remove nltk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 - Moved package install from the `datascience` environment to `root` (#8)
 - Clean the conda cache and skip recommended package installs to reduce Docker image size (#18)
 
+### Removed
+- nltk 3.2.2 (#20)
+
 ## [1.1.0] - 2017-02-13
 ### Changed
 - Add environment variables which record the image version number (#1)

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,6 @@ dependencies:
 - matplotlib=2.0.0
 - nomkl=1.0
 - nose=1.3.7
-- nltk=3.2.2
 - numexpr=2.6.2
 - numpy=1.12.0
 - openblas=0.2.19


### PR DESCRIPTION
Remove the NLTK package to slim down the Docker image, as it is probably used in text and NLP work only, and it can be easily installed through `conda` or `pip` if necessary.