### PR TITLE
[CIVP-10560] Update awscli to 1.11.60 to solve botocore python3 issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
 ## [Unreleased]
-
+### Changed
+- Various package version changes (#22)
+    - awscli 1.11.27 --> 1.11.60 
 
 ## [2.0.0] - 2017-03-09
 ### API-breaking changes

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
 - scikit-learn=0.18.1
 - statsmodels=0.8.0
 - pip:
-  - awscli==1.11.27
+  - awscli==1.11.60
   - civis==1.3.0
   - dropbox==7.1.1
   - ftputil==3.3.1


### PR DESCRIPTION
This PR updates the awscli version to enable the build to keep a python 3 compatible botocore version.