### PR TITLE
DOC Update to v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
 ## [Unreleased]
+
+
+## [2.0.1] - 2017-03-10
 ### Changed
 - Various package version changes (#22)
-    - awscli 1.11.27 --> 1.11.60 
+    - awscli 1.11.27 --> 1.11.60
 
 ## [2.0.0] - 2017-03-09
 ### API-breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 
 ## [2.0.1] - 2017-03-10
-### Changed
-- Various package version changes (#22)
-    - awscli 1.11.27 --> 1.11.60
+### Fixed
+- Update `awscli` to prevent pip conflict with `botocore`: awscli 1.11.27 --> 1.11.60 (#22)
 
 ## [2.0.0] - 2017-03-09
 ### API-breaking changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN echo "backend      : Agg" > ${HOME}/.config/matplotlib/matplotlibrc
 # Run matplotlib once to build the font cache
 RUN python -c "import matplotlib.pyplot"
 
-ENV VERSION=2.0.0 \
+ENV VERSION=2.0.1 \
     VERSION_MAJOR=2 \
     VERSION_MINOR=0 \
-    VERSION_MICRO=0
+    VERSION_MICRO=1


### PR DESCRIPTION
Prepare to tag v2.0.1 to make the fix for AWS utilities available.