### PR TITLE
ENH a little spring cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 - Changed name of environment in `environment.yml` file to `datascience` (but conda install is still `root`). (#26)
 - Removed a few Docker layers. (#26)
 - Cleared more of the `apt-get`, `pip` and `conda` caches. (#26)
+- Added a test of the `numpy` install. (#26)
 
 ## [2.0.1] - 2017-03-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
-## [Unreleased]
-
 ## [2.1.0] - 2017-03-17
 ### Changed
 - Upgrade `civis` to v1.4.0 (#25)
+- Changed name of environment in `environment.yml` file to `datascience` (but conda install is still `root`). (#26)
+- Removed a few Docker layers. (#26)
+- Cleared more of the `apt-get`, `pip` and `conda` caches. (#26)
 
 ## [2.0.1] - 2017-03-10
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,4 +95,4 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
 ENV VERSION=2.0.2 \
     VERSION_MAJOR=2 \
     VERSION_MINOR=0 \
-    VERSION_MICRO=2
+    VERSION_MICRO=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
     echo "backend      : Agg" > ${HOME}/.config/matplotlib/matplotlibrc && \
     python -c "import matplotlib.pyplot"
 
-ENV VERSION=2.0.2 \
+ENV VERSION=2.0.1 \
     VERSION_MAJOR=2 \
     VERSION_MINOR=0 \
     VERSION_MICRO=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
 # If you want to change the python version, you need to change it in
 # **both** places. The python version has been left in the `environment.yml`
 # file so that people can create environments equivalent to this
-# container. However, change the name of the environment first!
+# container.
 #
 # The ordering of these steps seems to matter. You seem to have to
 # install a specific python version by hand and then pin it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
     echo "backend      : Agg" > ${HOME}/.config/matplotlib/matplotlibrc && \
     python -c "import matplotlib.pyplot"
 
-ENV VERSION=2.0.1 \
+ENV VERSION=2.1.0 \
     VERSION_MAJOR=2 \
-    VERSION_MINOR=0 \
-    VERSION_MICRO=1
+    VERSION_MINOR=1 \
+    VERSION_MICRO=0

--- a/README.md
+++ b/README.md
@@ -59,10 +59,8 @@ VERSION_MINOR, and VERSION_MICRO each contain a single integer.
 
 # Creating Equivalent Local Environments
 
-The `environment.yml` file in this repo can be used to create a python environment that is 
-equivalent to the one in the container. **However, you should change the name of the 
-environment in the `environment.yml` file first!** Otherwise, you might stomp on packages in 
-your root environment or get an error.
+The `environment.yml` file in this repo can be used to create a python environment that is
+equivalent to the one in the container. This environment will be named `datascience`.
 
 # Contributing
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,3 +14,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "import seaborn"
         - docker run -t civisanalytics/datascience-python /bin/bash -c "python -c 'import numpy'"
         - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
+        - docker run civisanalytics/datascience-python python -c "import numpy; numpy.test()"

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: root
+name: datascience
 dependencies:
 - beautifulsoup4=4.5.3
 - boto=2.45.0


### PR DESCRIPTION
This PR
 - adds a test for `numpy`
 - combines a few layers
 - clears more of the `apt-get`, `pip` and `conda` caches for installs
 - renames the environment in the yaml file to 'datascience', but still installs to root