### PR TITLE
BUG Make environment potentially OS X installable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
+## Unreleased
+### Removed
+- Remove pinned conda installs of `libgcc` and `libsodium`. This prevented use of the environment file in OS X, and they are dependencies automatically installed by conda in the Docker image build.
+
+
 ## [2.1.0] - 2017-03-17
 ### Changed
 - Upgrade `civis` to v1.4.0 (#25)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ VERSION_MINOR, and VERSION_MICRO each contain a single integer.
 
 The `environment.yml` file in this repo can be used to create a python environment that is
 equivalent to the one in the container. This environment will be named `datascience`.
+The environment installs in Ubuntu Linux (this is the OS of the Dockerfile).
+It will install in OS X, but the `xgboost` install requires either
+the `gcc` v5 or the `clang-omp` compiler, neither of which are natively provided in OS X.
+If you wish to set up this environment in OS X, you may either
+- Remove `xgboost` from the `environment.yml` file before using it to create the environment
+- Use [Homebrew](https://brew.sh/) to install `gcc-5`. You can do that via
+`brew install gcc@5 --without-multilib`. Be warned that this installation will take
+a long time.
 
 # Contributing
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,9 +9,7 @@ dependencies:
 - jsonschema=2.5.1
 - jupyter=1.0.0
 - libffi=3.2.1
-- libgcc=5.2.0
 - libgfortran=3.0.0
-- libsodium=1.0.10
 - libtiff=4.0.6
 - libxml2=2.9.2
 - matplotlib=2.0.0


### PR DESCRIPTION
The gcc package we specified is not present in the OS X channels, so it blocked installation of this environment file in OS X. It's not necessary for any of the package installations, so remove it.