### PR TITLE
[CIVP-10979] Update installed package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ Version number changes (major.minor.micro) in this package denote the following:
 ### Removed
 - Remove pinned conda installs of `libgcc` and `libsodium`. This prevented use of the environment file in OS X, and they are dependencies automatically installed by conda in the Docker image build.
 
+### Additions
+- Explicitly added `botocore` v1.5.38. We had `botocore` installed before (it's a dependency of other AWS libraries), but we're now explicitly including the version number.
+
 ### Package updates
 - python 3.6.0 -> 3.6.1
+- awscli 1.11.60 -> 1.11.75
 - boto 2.45.0 -> 2.46.1
 - boto3 1.4.3 -> 1.4.4
 - numpy 1.12.0 -> 1.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,22 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
 ## Unreleased
+
+
+## [2.2.0] - 2017-05-02
 ### Removed
 - Remove pinned conda installs of `libgcc` and `libsodium`. This prevented use of the environment file in OS X, and they are dependencies automatically installed by conda in the Docker image build.
 
+### Package updates
+- python 3.6.0 -> 3.6.1
+- boto 2.45.0 -> 2.46.1
+- boto3 1.4.3 -> 1.4.4
+- numpy 1.12.0 -> 1.12.1
+- pubnub 4.0.8 -> 4.0.10
+- requests 2.12.4 -> 2.13.0
+- scipy 0.18.1 -> 0.19.0
+- muffnn 1.0.0 -> 1.1.1
+- tensorflow 1.0.0 -> 1.1.0
 
 ## [2.1.0] - 2017-03-17
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV LANG=en_US.UTF-8 \
     BASH_ENV=/etc/profile \
     PATH=/opt/conda/bin:$PATH \
     CIVIS_CONDA_VERSION=4.3.11 \
-    CIVIS_PYTHON_VERSION=3.6.0
+    CIVIS_PYTHON_VERSION=3.6.1
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
   apt-get install -y --no-install-recommends software-properties-common && \
@@ -92,7 +92,7 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
     echo "backend      : Agg" > ${HOME}/.config/matplotlib/matplotlibrc && \
     python -c "import matplotlib.pyplot"
 
-ENV VERSION=2.1.0 \
+ENV VERSION=2.2.0 \
     VERSION_MAJOR=2 \
-    VERSION_MINOR=1 \
+    VERSION_MINOR=2 \
     VERSION_MICRO=0

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: datascience
 dependencies:
 - beautifulsoup4=4.5.3
+- botocore=1.5.38
 - boto=2.46.1
 - boto3==1.4.4
 - cython=0.25.2
@@ -31,7 +32,7 @@ dependencies:
 - scikit-learn=0.18.1
 - statsmodels=0.8.0
 - pip:
-  - awscli==1.11.60
+  - awscli==1.11.75
   - civis==1.4.0
   - dropbox==7.1.1
   - ftputil==3.3.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,8 @@
 name: datascience
 dependencies:
 - beautifulsoup4=4.5.3
-- boto=2.45.0
-- boto3==1.4.3
+- boto=2.46.1
+- boto3==1.4.4
 - cython=0.25.2
 - ipython=5.1.0
 - jinja2=2.8
@@ -16,18 +16,18 @@ dependencies:
 - nomkl=1.0
 - nose=1.3.7
 - numexpr=2.6.2
-- numpy=1.12.0
+- numpy=1.12.1
 - openblas=0.2.19
 - pandas=0.19.2
 - patsy=0.4.1
 - psycopg2=2.6.2
 - pycrypto=2.6.1
 - pytest=3.0.5
-- python=3.6.0
+- python=3.6.1
 - pyyaml=3.12
-- requests=2.12.4
+- requests=2.13.0
 - seaborn=0.7.1
-- scipy=0.18.1
+- scipy=0.19.0
 - scikit-learn=0.18.1
 - statsmodels=0.8.0
 - pip:
@@ -37,11 +37,11 @@ dependencies:
   - ftputil==3.3.1
   - glmnet==2.0.0
   - joblib==0.11.0
-  - muffnn==1.0.0
-  - pubnub==4.0.8
+  - muffnn==1.1.1
+  - pubnub==4.0.10
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
   - requests-toolbelt==0.7.1
-  - tensorflow==1.0.0
+  - tensorflow==1.1.0
   - urllib3==1.19
   - xgboost==0.6a2


### PR DESCRIPTION
- python 3.6.0 -> 3.6.1
- awscli 1.11.60 -> 1.11.75
- boto 2.45.0 -> 2.46.1
- boto3 1.4.3 -> 1.4.4
- numpy 1.12.0 -> 1.12.1
- pubnub 4.0.8 -> 4.0.10
- requests 2.12.4 -> 2.13.0
- scipy 0.18.1 -> 0.19.0
- muffnn 1.0.0 -> 1.1.1
- tensorflow 1.0.0 -> 1.1.0

Explicitly added `botocore` v1.5.38. We had `botocore` installed before (it's a dependency of other AWS libraries), but we're now explicitly including the version number.
