### PR TITLE
Update civis-python to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
 ## Unreleased
+## [3.0.0] - 2017-05-17
 ### Package updates
-- civis 1.5.1 -> 1.5.2
-
-## [3.0.0] - 2017-05-16
-### Package updates
-- civis 1.4.0 -> 1.5.1
+- civis 1.4.0 -> 1.5.2
 - ipython 5.1.0 -> 6.0.0
 - matplotlib 2.0.0 -> 2.0.2
 - pandas 0.19.2 -> 0.20.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
 ## Unreleased
+### Package updates
+- civis 1.5.1 -> 1.5.2
 
 ## [3.0.0] - 2017-05-16
 ### Package updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
 ## Unreleased
+
 ## [3.0.0] - 2017-05-17
 ### Package updates
 - civis 1.4.0 -> 1.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
 - statsmodels=0.8.0
 - pip:
   - awscli==1.11.75
-  - civis==1.5.1
+  - civis==1.5.2
   - dropbox==7.1.1
   - ftputil==3.3.1
   - glmnet==2.0.0


### PR DESCRIPTION
This updates `civis` to the most recent version.