### PR TITLE
DEP Update package versions; add pyarrow and cloudpickle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+### New packages
+- cloudpickle 0.3.1
+- pyarrow 0.5.0 (from conda-forge)
+
+### Python
+- Update from v3.6.1 to v3.6.2
+
+### Package Updates
+- civis 1.5.2 -> 1.6.0
+- cython 0.25.2 -> 0.26
+- ipython 6.0.0 -> 6.1.0
+- jinja2 2.8 -> 2.9.6
+- numpy 1.12.1 -> 1.13.1
+- pandas 0.20.1 -> 0.20.3
+- pytest 3.0.5 -> 3.1.3
+- seaborn 0.7.1 -> 0.8
+- scipy 0.19.0 -> 0.19.1
+- scikit-learn 0.18.1 -> 0.18.2
+- pubnub 4.0.10 -> 4.0.12
+- requests-toolbelt 0.7.1 -> 0.8.0
+- tensorflow 1.1.0 -> 1.2.1
+
+### Changed
+- Install xgboost from conda-forge instead of from PyPI
+
 ### Fixes
 - Use /tmp for joblib temporary files instead of /shm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV LANG=en_US.UTF-8 \
     BASH_ENV=/etc/profile \
     PATH=/opt/conda/bin:$PATH \
     CIVIS_CONDA_VERSION=4.3.11 \
-    CIVIS_PYTHON_VERSION=3.6.1
+    CIVIS_PYTHON_VERSION=3.6.2
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
   apt-get install -y --no-install-recommends software-properties-common && \

--- a/circle.yml
+++ b/circle.yml
@@ -15,3 +15,4 @@ test:
         - docker run -t civisanalytics/datascience-python /bin/bash -c "python -c 'import numpy'"
         - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
         - docker run civisanalytics/datascience-python python -c "import numpy; numpy.test()"
+        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; assert int(sys.stdin.readlines()[0]) == 5, 'There should be 5 conda-forge packages'\""

--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,15 @@
 name: datascience
+channels:
+- defaults
+- conda-forge
 dependencies:
 - beautifulsoup4=4.5.3
 - botocore=1.5.38
 - boto=2.46.1
 - boto3==1.4.4
-- cython=0.25.2
-- ipython=6.0.0
-- jinja2=2.8
+- cython=0.26
+- ipython=6.1.0
+- jinja2=2.9.6
 - jsonschema=2.5.1
 - jupyter=1.0.0
 - libffi=3.2.1
@@ -17,32 +20,34 @@ dependencies:
 - nomkl=1.0
 - nose=1.3.7
 - numexpr=2.6.2
-- numpy=1.12.1
+- numpy=1.13.1
 - openblas=0.2.19
-- pandas=0.20.1
+- pandas=0.20.3
 - patsy=0.4.1
 - psycopg2=2.6.2
+- pyarrow=0.5.0
 - pycrypto=2.6.1
-- pytest=3.0.5
-- python=3.6.1
+- pytest=3.1.3
+- python=3.6.2
 - pyyaml=3.12
 - requests=2.14.2
-- seaborn=0.7.1
-- scipy=0.19.0
-- scikit-learn=0.18.1
+- seaborn=0.8
+- scipy=0.19.1
+- scikit-learn=0.18.2
 - statsmodels=0.8.0
+- xgboost=0.6a2
 - pip:
   - awscli==1.11.75
-  - civis==1.5.2
+  - civis==1.6.0
+  - cloudpickle==0.3.1
   - dropbox==7.1.1
   - ftputil==3.3.1
   - glmnet==2.0.0
   - joblib==0.11.0
   - muffnn==1.1.2
-  - pubnub==4.0.10
+  - pubnub==4.0.12
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
-  - requests-toolbelt==0.7.1
-  - tensorflow==1.1.0
+  - requests-toolbelt==0.8.0
+  - tensorflow==1.2.1
   - urllib3==1.19
-  - xgboost==0.6a2


### PR DESCRIPTION
### New packages
- cloudpickle 0.3.1
- pyarrow 0.5.0 (from conda-forge)

### Python
- Update from v3.6.1 to v3.6.2

### Package Updates
- civis 1.5.2 -> 1.6.0
- cython 0.25.2 -> 0.26
- ipython 6.0.0 -> 6.1.0
- jinja2 2.8 -> 2.9.6
- numpy 1.12.1 -> 1.13.1
- pandas 0.20.1 -> 0.20.3
- pytest 3.0.5 -> 3.1.3
- seaborn 0.7.1 -> 0.8
- scipy 0.19.0 -> 0.19.1
- scikit-learn 0.18.1 -> 0.18.2
- pubnub 4.0.10 -> 4.0.12
- requests-toolbelt 0.7.1 -> 0.8.0
- tensorflow 1.1.0 -> 1.2.1
