### PR TITLE
[CIVP-12352] DEP update sklearn version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+### New packages
+- scikit-learn 0.18.2 -> 0.19.0
+
 ## [3.1.0] - 2017-07-31
 ### New packages
 - cloudpickle 0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
 
 ## Unreleased
-
-### New packages
+### Package Updates
 - scikit-learn 0.18.2 -> 0.19.0
 
 ## [3.1.0] - 2017-07-31

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
 - requests=2.14.2
 - seaborn=0.8
 - scipy=0.19.1
-- scikit-learn=0.18.2
+- scikit-learn=0.19.0
 - statsmodels=0.8.0
 - xgboost=0.6a2
 - pip:


### PR DESCRIPTION
Update sklearn version to most recent version, 0.19.0.