### PR TITLE
[CIVP-12592] Update requests to 2.18.4 (and urllib3 to 1.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 ### Package Updates
 - scikit-learn 0.18.2 -> 0.19.0
 - civis 1.6.0 -> 1.6.2
+- requests 2.14.2 -> 2.18.4
 
 ## [3.1.0] - 2017-07-31
 ### New packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 - scikit-learn 0.18.2 -> 0.19.0
 - civis 1.6.0 -> 1.6.2
 - requests 2.14.2 -> 2.18.4
+- urllib3 1.19 -> 1.22
 
 ## [3.1.0] - 2017-07-31
 ### New packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All changes to this project will be documented in this file.
 Version number changes (major.minor.micro) in this package denote the following:
 - A micro version will increase if the only change in a release is incrementing micro versions (bugfix-only releases) on the packages contained in this image.
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
-- A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompabile changes in the execution environment.
+- A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompatible changes in the execution environment.
 
 ## Unreleased
 ### Package Updates

--- a/circle.yml
+++ b/circle.yml
@@ -15,4 +15,5 @@ test:
         - docker run -t civisanalytics/datascience-python /bin/bash -c "python -c 'import numpy'"
         - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
         - docker run civisanalytics/datascience-python python -c "import numpy; numpy.test()"
-        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; assert int(sys.stdin.readlines()[0]) == 5, 'There should be 5 conda-forge packages'\""
+        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep conda-forge"
+        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 7; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""

--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies:
 - pytest=3.1.3
 - python=3.6.2
 - pyyaml=3.12
+- requests=2.14.2
 - seaborn=0.8
 - scipy=0.19.1
 - scikit-learn=0.19.0
@@ -47,7 +48,6 @@ dependencies:
   - pubnub==4.0.12
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
-  - requests==2.18.4
   - requests-toolbelt==0.8.0
   - tensorflow==1.2.1
   - urllib3==1.22

--- a/environment.yml
+++ b/environment.yml
@@ -50,4 +50,4 @@ dependencies:
   - requests==2.18.4
   - requests-toolbelt==0.8.0
   - tensorflow==1.2.1
-  - urllib3==1.19
+  - urllib3==1.22

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
 - pytest=3.1.3
 - python=3.6.2
 - pyyaml=3.12
-- requests=2.14.2
+- requests=2.18.4
 - seaborn=0.8
 - scipy=0.19.1
 - scikit-learn=0.19.0

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,6 @@ dependencies:
 - pytest=3.1.3
 - python=3.6.2
 - pyyaml=3.12
-- requests=2.14.2
 - seaborn=0.8
 - scipy=0.19.1
 - scikit-learn=0.19.0
@@ -48,6 +47,7 @@ dependencies:
   - pubnub==4.0.12
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
+  - requests==2.18.4
   - requests-toolbelt==0.8.0
   - tensorflow==1.2.1
   - urllib3==1.19


### PR DESCRIPTION
This PR updates the version of `requests` to the most up-to-date 2.18.4, so that we can take advantage of some of the recently added features, e.g. the `with` context manager syntax of a `requests` response.

EDIT 2017-09-08: It looks like the latest `requests` v2.18.4 throws a `RequestsDependencyWarning` for the slightly out-of-date version of `urllib3`. For this reason, this ticket also includes updating `urllib3`, from 1.19 to 1.22.