### PR TITLE
MAINT Update version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompatible changes in the execution environment.
 
 ## Unreleased
+
+
+## [3.2.0] - 2017-09-11
 ### Package Updates
 - scikit-learn 0.18.2 -> 0.19.0
 - civis 1.6.0 -> 1.6.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=3.1.0 \
+ENV VERSION=3.2.0 \
     VERSION_MAJOR=3 \
-    VERSION_MINOR=1 \
+    VERSION_MINOR=2 \
     VERSION_MICRO=0


### PR DESCRIPTION
Changes for this release:

### Package Updates
- scikit-learn 0.18.2 -> 0.19.0
- civis 1.6.0 -> 1.6.2
- requests 2.14.2 -> 2.18.4
- urllib3 1.19 -> 1.22
