### PR TITLE
V3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompatible changes in the execution environment.
 
-## Unreleased
+## [3.3.0] - 2017-10-05
 ### New packages
-- civisml-extensions 0.1.1
+- civisml-extensions 0.1.3
 
 ## [3.2.0] - 2017-09-11
 ### Package Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompatible changes in the execution environment.
 
-## [3.3.0] - 2017-10-05
+## [3.3.0] - 2017-10-30
 ### New packages
-- civisml-extensions 0.1.3
+- civisml-extensions 0.1.5
 
 ## [3.2.0] - 2017-09-11
 ### Package Updates

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=3.2.0 \
+ENV VERSION=3.3.0 \
     VERSION_MAJOR=3 \
-    VERSION_MINOR=2 \
+    VERSION_MINOR=3 \
     VERSION_MICRO=0

--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,7 @@ dependencies:
 - pip:
   - awscli==1.11.75
   - civis==1.6.2
-  - civisml-extensions==0.1.1
+  - civisml-extensions==0.1.3
   - cloudpickle==0.3.1
   - dropbox==7.1.1
   - ftputil==3.3.1

--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,7 @@ dependencies:
 - pip:
   - awscli==1.11.75
   - civis==1.6.2
-  - civisml-extensions==0.1.3
+  - civisml-extensions==0.1.5
   - cloudpickle==0.3.1
   - dropbox==7.1.1
   - ftputil==3.3.1


### PR DESCRIPTION
Release a new minor version of datascience-python with civisml-extensions. To be merged after https://github.com/civisanalytics/civisml-extensions/pull/13.