### PR TITLE
DEP Update package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,24 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompatible changes in the execution environment.
 
 ## Unreleased
+
 ### New packages
 - civisml-extensions 0.1.1
+
+### Changed
+- Moved conda to version 4.3.30
+
+### Package Updates
+- boto3 1.4.4 -> 1.4.5
+- matplotlib 2.0.2 -> 2.1.0
+- numpy 1.13.1 -> 1.13.3
+- pandas 0.20.3 -> 0.21.0
+- pyarrow 0.5.0 -> 0.7.1
+- scikit-learn 0.19.0 -> 0.19.1
+- cloudpickle 0.3.1 -> 0.5.1
+- muffnn 1.1.2 -> 1.2.0
+- pubnub 4.0.12 -> 4.0.13
+- tensorflow 1.2.1 -> 1.4.0
 
 ## [3.2.0] - 2017-09-11
 ### Package Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ### New packages
 - civisml-extensions 0.1.1
+- dask 0.15.4
+- s3fs 0.1.2
 
 ### Changed
 - Moved conda to version 4.3.30

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV LANG=en_US.UTF-8 \
     CONDARC=/opt/conda/.condarc \
     BASH_ENV=/etc/profile \
     PATH=/opt/conda/bin:$PATH \
-    CIVIS_CONDA_VERSION=4.3.11 \
+    CIVIS_CONDA_VERSION=4.3.30 \
     CIVIS_PYTHON_VERSION=3.6.2
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
         - docker run civisanalytics/datascience-python python -c "import numpy; numpy.test()"
         - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep conda-forge"
-        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 7; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""
+        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 9; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""

--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,7 @@ dependencies:
 - python=3.6.2
 - pyyaml=3.12
 - requests=2.18.4
+- s3fs=0.1.2
 - seaborn=0.8
 - scipy=0.19.1
 - scikit-learn=0.19.1
@@ -41,6 +42,7 @@ dependencies:
   - civis==1.6.2
   - civisml-extensions==0.1.1
   - cloudpickle==0.5.1
+  - dask==0.15.4
   - dropbox==7.1.1
   - ftputil==3.3.1
   - glmnet==2.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - beautifulsoup4=4.5.3
 - botocore=1.5.38
 - boto=2.46.1
-- boto3==1.4.4
+- boto3==1.4.5
 - cython=0.26
 - ipython=6.1.0
 - jinja2=2.9.6
@@ -16,16 +16,16 @@ dependencies:
 - libgfortran=3.0.0
 - libtiff=4.0.6
 - libxml2=2.9.2
-- matplotlib=2.0.2
+- matplotlib=2.1.0
 - nomkl=1.0
 - nose=1.3.7
 - numexpr=2.6.2
-- numpy=1.13.1
+- numpy=1.13.3
 - openblas=0.2.19
-- pandas=0.20.3
+- pandas=0.21.0
 - patsy=0.4.1
 - psycopg2=2.6.2
-- pyarrow=0.5.0
+- pyarrow=0.7.1
 - pycrypto=2.6.1
 - pytest=3.1.3
 - python=3.6.2
@@ -33,22 +33,22 @@ dependencies:
 - requests=2.18.4
 - seaborn=0.8
 - scipy=0.19.1
-- scikit-learn=0.19.0
+- scikit-learn=0.19.1
 - statsmodels=0.8.0
 - xgboost=0.6a2
 - pip:
   - awscli==1.11.75
   - civis==1.6.2
   - civisml-extensions==0.1.1
-  - cloudpickle==0.3.1
+  - cloudpickle==0.5.1
   - dropbox==7.1.1
   - ftputil==3.3.1
   - glmnet==2.0.0
   - joblib==0.11.0
-  - muffnn==1.1.2
-  - pubnub==4.0.12
+  - muffnn==1.2.0
+  - pubnub==4.0.13
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
   - requests-toolbelt==0.8.0
-  - tensorflow==1.2.1
+  - tensorflow==1.4.0
   - urllib3==1.22


### PR DESCRIPTION
- boto3 1.4.4 -> 1.4.5
- matplotlib 2.0.2 -> 2.1.0
- numpy 1.13.1 -> 1.13.3
- pandas 0.20.3 -> 0.21.0
- pyarrow 0.5.0 -> 0.7.1
- scikit-learn 0.19.0 -> 0.19.1
- cloudpickle 0.3.1 -> 0.5.1
- muffnn 1.1.2 -> 1.2.0
- pubnub 4.0.12 -> 4.0.13
- tensorflow 1.2.1 -> 1.4.0

Also upgrade conda to 4.3.30 (latest miniconda version) to avoid a conda bug which prevented package installation.