### PR TITLE
[CIVP-12555] fix jupyter widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A minor version will increase if one or more packages contained in the Docker image add new, backwards-compatible features, or if a new package is added to the Docker image.
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompatible changes in the execution environment.
 
+## Unreleased
+### New packages
+- bqplot 0.10.1
+
+### Package Updates
+- ipywidgets 7.0.0 -> 7.0.5
+- notebook 5.2.0 -> 5.2.1
+
+### Fixed
+- Enabled widgetsnbextension so that ipywidgets works.
+
 ## [3.3.0] - 2017-11-17
 ### Package Updates
 - civis 1.6.2 -> 1.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 ### New packages
-- bqplot 0.10.1
+- bqplot 0.10.2
 
 ### Package Updates
-- ipywidgets 7.0.0 -> 7.0.5
-- notebook 5.2.0 -> 5.2.1
+- ipywidgets 7.0.0 -> 7.1.0
+- notebook 5.2.0 -> 5.2.2
 
 ### Fixed
 - Enabled widgetsnbextension so that ipywidgets works.

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,11 +92,6 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
     echo "backend      : Agg" > ${HOME}/.config/matplotlib/matplotlibrc && \
     python -c "import matplotlib.pyplot"
 
-# Enable widgetsnbextension for jupyter widgets.
-# See https://ipywidgets.readthedocs.io/en/stable/user_install.html.
-# This enables the extension in the conda environment.
-RUN jupyter nbextension enable --py widgetsnbextension
-
 # Instruct joblib to use disk for temporary files. Joblib defaults to
 # /shm when that directory is present. In the Docker container, /shm is
 # present but defaults to 64 MB.

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,13 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
     echo "backend      : Agg" > ${HOME}/.config/matplotlib/matplotlibrc && \
     python -c "import matplotlib.pyplot"
 
+# Enable widgetsnbextension for jupyter widgets.
+# See https://ipywidgets.readthedocs.io/en/stable/user_install.html.
+# This enables the extension in the conda environment. The conda-forge version
+# does this upon installation, but the default channel version doesn't seem to,
+# so we'll run this (again) just in case.
+RUN jupyter nbextension enable --py widgetsnbextension
+
 # Instruct joblib to use disk for temporary files. Joblib defaults to
 # /shm when that directory is present. In the Docker container, /shm is
 # present but defaults to 64 MB.

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,11 @@ RUN mkdir -p ${HOME}/.config/matplotlib && \
     echo "backend      : Agg" > ${HOME}/.config/matplotlib/matplotlibrc && \
     python -c "import matplotlib.pyplot"
 
+# Enable widgetsnbextension for jupyter widgets.
+# See https://ipywidgets.readthedocs.io/en/stable/user_install.html.
+# This enables the extension in the conda environment.
+RUN jupyter nbextension enable --py widgetsnbextension
+
 # Instruct joblib to use disk for temporary files. Joblib defaults to
 # /shm when that directory is present. In the Docker container, /shm is
 # present but defaults to 64 MB.

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
         - docker run civisanalytics/datascience-python python -c "import numpy; numpy.test()"
         - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep conda-forge"
-        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 8; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""
+        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 10; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
         - docker run civisanalytics/datascience-python python -c "import numpy; numpy.test()"
         - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep conda-forge"
-        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 9; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""
+        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 8; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""

--- a/environment.yml
+++ b/environment.yml
@@ -7,10 +7,10 @@ dependencies:
 - botocore=1.5.38
 - boto=2.46.1
 - boto3==1.4.5
-- bqplot=0.10.1
+- bqplot=0.10.2
 - cython=0.26
 - ipython=6.1.0
-- ipywidgets=7.0.5
+- ipywidgets=7.1.0
 - jinja2=2.9.6
 - jsonschema=2.5.1
 - jupyter=1.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,10 @@ dependencies:
 - botocore=1.5.38
 - boto=2.46.1
 - boto3==1.4.5
+- bqplot=0.10.1
 - cython=0.26
 - ipython=6.1.0
+- ipywidgets=7.0.5
 - jinja2=2.9.6
 - jsonschema=2.5.1
 - jupyter=1.0.0
@@ -18,6 +20,7 @@ dependencies:
 - libxml2=2.9.2
 - matplotlib=2.1.0
 - nomkl=1.0
+- notebook=5.2.2
 - nose=1.3.7
 - numexpr=2.6.2
 - numpy=1.13.3


### PR DESCRIPTION
The jupyter widgets package (ipywidgets) was included in the image previously via the jupyter dependency, but they didn't work.

This pins the `ipywidgets` and `notebook` versions and adds the nice `bqplot` viz package that uses jupyter widgets in `environment.yml`.  It also adds a command to the dockerfile to enable jupyter widgets since the conda package doesn't appear to do that.