### PR TITLE
ENH Update packages for new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,29 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompatible changes in the execution environment.
 
 ## Unreleased
+
+## [4.0.0] - 2018-01-23
 ### New packages
 - bqplot 0.10.2
+- feather-format 0.4.0
+
+### Changed
+- Updated Python version from 3.6.2 to 3.6.4.
 
 ### Package Updates
+- civis 1.7.1 -> 1.8.0
+- civisml-extensions 0.1.5 -> 0.1.6
+- muffnn 1.2.0 -> 2.0.0
+- cloudpickle 0.5.1 -> 0.5.2
+- dask 0.15.4 -> 0.16.1
+- ftputil 3.3.1 -> 3.4
+- tensorflow 1.4.0 -> 1.4.1
+- boto3 1.4.5 -> 1.5.11
+- cython 0.26 -> 0.27.3
+- openblas 0.2.19 -> 0.2.20
+- pandas 0.21.0 -> 0.22.0
+- pyarrow 0.7.1 -> 0.8.0
+- scipy 0.19.1 -> 1.0.0
 - ipywidgets 7.0.0 -> 7.1.0
 - notebook 5.2.0 -> 5.2.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV LANG=en_US.UTF-8 \
     BASH_ENV=/etc/profile \
     PATH=/opt/conda/bin:$PATH \
     CIVIS_CONDA_VERSION=4.3.30 \
-    CIVIS_PYTHON_VERSION=3.6.2
+    CIVIS_PYTHON_VERSION=3.6.4
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
   apt-get install -y --no-install-recommends software-properties-common && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ RUN jupyter nbextension enable --py widgetsnbextension
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=3.3.0 \
-    VERSION_MAJOR=3 \
-    VERSION_MINOR=3 \
+ENV VERSION=4.0.0 \
+    VERSION_MAJOR=4 \
+    VERSION_MINOR=0 \
     VERSION_MICRO=0

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,10 @@ dependencies:
 - beautifulsoup4=4.5.3
 - botocore=1.5.38
 - boto=2.46.1
-- boto3==1.4.5
+- boto3==1.5.11
 - bqplot=0.10.2
-- cython=0.26
+- cython=0.27.3
+- feather-format=0.4.0
 - ipython=6.1.0
 - ipywidgets=7.1.0
 - jinja2=2.9.6
@@ -24,36 +25,36 @@ dependencies:
 - nose=1.3.7
 - numexpr=2.6.2
 - numpy=1.13.3
-- openblas=0.2.19
-- pandas=0.21.0
+- openblas=0.2.20
+- pandas=0.22.0
 - patsy=0.4.1
 - psycopg2=2.6.2
-- pyarrow=0.7.1
+- pyarrow=0.8.0
 - pycrypto=2.6.1
 - pytest=3.1.3
-- python=3.6.2
+- python=3.6.4
 - pyyaml=3.12
 - requests=2.18.4
 - s3fs=0.1.2
 - seaborn=0.8
-- scipy=0.19.1
+- scipy=1.0.0
 - scikit-learn=0.19.1
 - statsmodels=0.8.0
 - xgboost=0.6a2
 - pip:
   - awscli==1.11.75
-  - civis==1.7.1
-  - civisml-extensions==0.1.5
-  - cloudpickle==0.5.1
+  - civis==1.8.0
+  - civisml-extensions==0.1.6
+  - cloudpickle==0.5.2
   - dask==0.15.4
   - dropbox==7.1.1
-  - ftputil==3.3.1
+  - ftputil==3.4
   - glmnet==2.0.0
   - joblib==0.11.0
-  - muffnn==1.2.0
+  - muffnn==2.0.0
   - pubnub==4.0.13
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
   - requests-toolbelt==0.8.0
-  - tensorflow==1.4.0
+  - tensorflow==1.4.1
   - urllib3==1.22


### PR DESCRIPTION
This will be a major version increase because of major version increases in `scipy` and `muffnn`, and a single breaking change in `pandas`.

Updated Python version from 3.6.2 to 3.6.4.

Addition:
- feather-format 0.4.0

Updates:
- civis 1.7.1 -> 1.8.0
- civisml-extensions 0.1.5 -> 0.1.6
- muffnn 1.2.0 -> 2.0.0
- cloudpickle 0.5.1 -> 0.5.2
- dask 0.15.4 -> 0.16.1
- boto3 1.4.5 -> 1.5.11
- cython 0.26 -> 0.27.3
- openblas 0.2.19 -> 0.2.20
- pandas 0.21.0 -> 0.22.0
- pyarrow 0.7.1 -> 0.8.0
- scipy 0.19.1 -> 1.0.0