### PR TITLE
DOC Direct users from DockerHub to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+### Added
+- Added a link in the README directing users who may be reading documentation on DockerHub to instead go to GitHub (#56).
+
 ## [4.0.1] - 2018-02-01
 ### Package Updates
 - civis 1.8.0 -> 1.8.1

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This image is created from the official Ubuntu 14.04 Docker image and contains popular Python packages for data science.
 
+If you are reading this README on DockerHub, then the links to files in the GitHub respository will be broken. Please read this documentation from [GitHub](https://github.com/civisanalytics/datascience-python) instead.
+
 # Introduction
 
 This repository defines the "[civisanalytics/datascience-python](https://hub.docker.com/r/civisanalytics/datascience-python/)"


### PR DESCRIPTION
The DockerHub autobuild includes the README from GitHub, which is good. However, the README includes relative links which GitHub parses correctly but DockerHub does not. Therefore, direct users to read the README on GitHub instead of DockerHub.

Closes #54 .