### PR TITLE
DEP Update versions of boto3, botocore, and awscli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 - Added a link in the README directing users who may be reading documentation on DockerHub to instead go to GitHub (#56).
 
 ### Package Updates
+- awscli 1.11.75 (from pip) -> 1.15.4 (from conda)
 - botocore 1.5.38 -> 1.10.4
 - boto3 1.5.11 -> 1.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Version number changes (major.minor.micro) in this package denote the following:
 ### Added
 - Added a link in the README directing users who may be reading documentation on DockerHub to instead go to GitHub (#56).
 
+### Package Updates
+- botocore 1.5.38 -> 1.10.4
+- boto3 1.5.11 -> 1.7.4
+
 ## [4.0.1] - 2018-02-01
 ### Package Updates
 - civis 1.8.0 -> 1.8.1

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
         - docker run civisanalytics/datascience-python python -c "import numpy; numpy.test()"
         - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep conda-forge"
-        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 10; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""
+        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 11; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
         - docker run civisanalytics/datascience-python python -c "import numpy; numpy.test()"
         - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep conda-forge"
-        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 10; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""
+        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 9; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ test:
         - docker run civisanalytics/datascience-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
         - docker run civisanalytics/datascience-python python -c "import numpy; numpy.test()"
         - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep conda-forge"
-        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 9; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""
+        - docker run civisanalytics/datascience-python /bin/bash -c "conda list|grep -c conda-forge|python -c \"import sys; actual_count = int(sys.stdin.readlines()[0]); expected_count = 10; assert actual_count == expected_count, 'There should be %d conda-forge packages, but there are actually %d.' % (expected_count, actual_count)\""

--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,9 @@ channels:
 - conda-forge
 dependencies:
 - beautifulsoup4=4.5.3
-- botocore=1.5.38
+- botocore=1.10.4
 - boto=2.46.1
-- boto3==1.5.11
+- boto3=1.7.4
 - bqplot=0.10.2
 - cython=0.27.3
 - feather-format=0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
 - defaults
 - conda-forge
 dependencies:
+- awscli=1.15.4
 - beautifulsoup4=4.5.3
 - botocore=1.10.4
 - boto=2.46.1
@@ -42,7 +43,6 @@ dependencies:
 - statsmodels=0.8.0
 - xgboost=0.6a2
 - pip:
-  - awscli==1.11.75
   - civis==1.8.1
   - civisml-extensions==0.1.6
   - cloudpickle==0.5.2


### PR DESCRIPTION
As per offline discussion with @stephen-hoover, this PR resolves #57 to update the versions of `boto3` and `botocore` for a release. (Other packages in `environment.yml` probably also need updating for their versions, but this will be done separately in the near future.)

@stephen-hoover, I haven't updated `CHANGELOG.md` and `Dockerfile` for a new version number. Please let me know if you want me to pin down a new one within this PR as well (if you do, it is 4.1.0 for a minor release as this PR updates the minor versions of included packages, correct?).

Update: This PR also updates the version of `awscli` to 1.15.4, as it requires `botocore`.