### PR TITLE
MAINT Update version to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [4.1.0] - 2018-04-19
 ### Added
 - Added a link in the README directing users who may be reading documentation on DockerHub to instead go to GitHub (#56).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ ENV JOBLIB_TEMP_FOLDER=/tmp
 RUN mkdir -p /root/.local/lib/python3.6/site-packages
 COPY warningsfilter.py /root/.local/lib/python3.6/site-packages/usercustomize.py
 
-ENV VERSION=4.0.1 \
+ENV VERSION=4.1.0 \
     VERSION_MAJOR=4 \
-    VERSION_MINOR=0 \
-    VERSION_MICRO=1
+    VERSION_MINOR=1 \
+    VERSION_MICRO=0


### PR DESCRIPTION
Changes for this release:

### Added
- Added a link in the README directing users who may be reading documentation on DockerHub to instead go to GitHub (#56).

### Package Updates
- awscli 1.11.75 (from pip) -> 1.15.4 (from conda)
- botocore 1.5.38 -> 1.10.4
- boto3 1.5.11 -> 1.7.4