### PR TITLE
DEP Update packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+
+## [4.2.0] - 2018-04-26
+### Package Updates
+- civis 1.8.1 -> 1.9.0
+- civisml-extensions 0.1.6 -> 0.1.8
+- muffnn 2.0.0 -> 2.1.0
+
+- dask 0.15.4 (pip) -> 0.17.2 (conda)
+- tensorflow 1.4.1 -> 1.7.0
+- ipython 6.1.0 -> 6.3.1
+- matplotlib 2.1.0 -> 2.2.2
+- notebook 5.2.2 -> 5.4.1
+- scipy 1.0.0 -> 1.0.1
+- urllib3 1.22 (pip) -> 1.22 (conda)
+
 ## [4.1.0] - 2018-04-19
 ### Added
 - Added a link in the README directing users who may be reading documentation on DockerHub to instead go to GitHub (#56).

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,14 +105,7 @@ RUN jupyter nbextension enable --py widgetsnbextension
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-# Filter out irrelevant warnings.
-# This section should be removed when it's no longer needed.
-# As of container version 4.0.0, it filters a tensorflow warning
-# which should go away with tensorflow v1.5.
-RUN mkdir -p /root/.local/lib/python3.6/site-packages
-COPY warningsfilter.py /root/.local/lib/python3.6/site-packages/usercustomize.py
-
-ENV VERSION=4.1.0 \
+ENV VERSION=4.2.0 \
     VERSION_MAJOR=4 \
-    VERSION_MINOR=1 \
+    VERSION_MINOR=2 \
     VERSION_MICRO=0

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
 - boto3=1.7.4
 - bqplot=0.10.2
 - cython=0.27.3
+- dask=0.17.2
 - feather-format=0.4.0
 - ipython=6.1.0
 - ipywidgets=7.1.0
@@ -20,9 +21,9 @@ dependencies:
 - libgfortran=3.0.0
 - libtiff=4.0.6
 - libxml2=2.9.2
-- matplotlib=2.1.0
+- matplotlib=2.2.2
 - nomkl=1.0
-- notebook=5.2.2
+- notebook=5.4.1
 - nose=1.3.7
 - numexpr=2.6.2
 - numpy=1.13.3
@@ -38,23 +39,22 @@ dependencies:
 - requests=2.18.4
 - s3fs=0.1.2
 - seaborn=0.8
-- scipy=1.0.0
+- scipy=1.0.1
 - scikit-learn=0.19.1
 - statsmodels=0.8.0
+- urllib3=1.22
 - xgboost=0.6a2
 - pip:
-  - civis==1.8.1
-  - civisml-extensions==0.1.6
+  - civis==1.9.0
+  - civisml-extensions==0.1.8
   - cloudpickle==0.5.2
-  - dask==0.15.4
   - dropbox==7.1.1
   - ftputil==3.4
   - glmnet==2.0.0
   - joblib==0.11.0
-  - muffnn==2.0.0
+  - muffnn==2.1.0
   - pubnub==4.0.13
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0
   - requests-toolbelt==0.8.0
-  - tensorflow==1.4.1
-  - urllib3==1.22
+  - tensorflow==1.7.0

--- a/warningsfilter.py
+++ b/warningsfilter.py
@@ -1,5 +1,0 @@
-import warnings
-
-# This warning is raised from tensorflow v1.4 at import time.
-# It's irrelevant and should be ignored.
-warnings.filterwarnings('ignore', "compiletime version 3.5 of module 'tensorflow.python.framework.fast_tensor_util' does not match runtime version 3.6", category=RuntimeWarning)


### PR DESCRIPTION
Also update container version number and remove the no-longer-needed warning suppression for tensorflow.

Package Updates
- civis 1.8.1 -> 1.9.0
- civisml-extensions 0.1.6 -> 0.1.8
- muffnn 2.0.0 -> 2.1.0

- dask 0.15.4 (pip) -> 0.17.2 (conda)
- tensorflow 1.4.1 -> 1.7.0
- ipython 6.1.0 -> 6.3.1
- matplotlib 2.1.0 -> 2.2.2
- notebook 5.2.2 -> 5.4.1
- scipy 1.0.0 -> 1.0.1
- urllib3 1.22 (pip) -> 1.22 (conda)