### PR TITLE
MAINT update ubuntu version and version in ENV

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ jobs:
           name: Check that numpy imports from bash shell
           command: docker run -t ds-python /bin/bash -c "python -c 'import numpy'"
       - run:
+          name: Check that tensorflow imports from bash shell
+          command: docker run ds-python /bin/bash -c "python -c 'import tensorflow'"
+      - run:
           name: Verify that numpy does not link to MKL
           command: docker run ds-python python -c "from numpy.distutils import system_info; assert system_info.get_info('mkl') == {}"
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## [5.0.0] - 2019-03-12
 ### Changed
+- Ubuntu 14.04 -> 18.04 (#67)
 - python 3.6.4 -> 3.7.1
 - conda 4.3.30 -> 4.6.8
 
@@ -61,9 +62,9 @@ Version number changes (major.minor.micro) in this package denote the following:
 - requests-toolbelt 0.8.0 -> 0.9.1
 - tensorflow 1.7.0 -> 1.13.1
 
-
 ### Maintenance
 - Update CircleCI config to v2 (#62).
+- Test that tensorflow imports successfully (#67).
 
 ## [4.2.0] - 2018-04-26
 ### Package Updates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04.1
 MAINTAINER support@civisanalytics.com
 
 # Ensure UTF-8 locale.
@@ -107,7 +107,7 @@ RUN jupyter nbextension enable --py widgetsnbextension
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=4.2.0 \
-    VERSION_MAJOR=4 \
-    VERSION_MINOR=2 \
+ENV VERSION=5.0.0 \
+    VERSION_MAJOR=5 \
+    VERSION_MINOR=0 \
     VERSION_MICRO=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04.1
+FROM ubuntu:18.04
 MAINTAINER support@civisanalytics.com
 
 # Ensure UTF-8 locale.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 MAINTAINER support@civisanalytics.com
 
 # Ensure UTF-8 locale.
+RUN apt-get install locales
 RUN locale-gen en_US.UTF-8
 
 # Set environment variables for UTF-8, conda, and shell environments

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,9 @@
 FROM ubuntu:18.04
 MAINTAINER support@civisanalytics.com
 
-# Ensure UTF-8 locale.
-RUN apt-get install locales
-RUN locale-gen en_US.UTF-8
-
-# Set environment variables for UTF-8, conda, and shell environments
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8 \
-    CONDARC=/opt/conda/.condarc \
-    BASH_ENV=/etc/profile \
-    PATH=/opt/conda/bin:$PATH \
-    CIVIS_MINICONDA_VERSION=4.5.12 \
-    CIVIS_CONDA_VERSION=4.6.8 \
-    CIVIS_PYTHON_VERSION=3.7.1
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
+  apt-get install -y --no-install-recommends locales && \
+  locale-gen en_US.UTF-8 && \
   apt-get install -y --no-install-recommends software-properties-common && \
   apt-get install -y --no-install-recommends \
         make \
@@ -34,6 +21,17 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
         curl && \
   apt-get clean -y && \
   rm -rf /var/lib/apt/lists/*
+
+# Set environment variables for UTF-8, conda, and shell environments
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    CONDARC=/opt/conda/.condarc \
+    BASH_ENV=/etc/profile \
+    PATH=/opt/conda/bin:$PATH \
+    CIVIS_MINICONDA_VERSION=4.5.12 \
+    CIVIS_CONDA_VERSION=4.6.8 \
+    CIVIS_PYTHON_VERSION=3.7.1
 
 # Conda install.
 #


### PR DESCRIPTION
This PR updates ubuntu to the latest LTS. Ubuntu 14.04 does not work with the latest tensorflow release because of a CUDA dependency. I'm also updating the version number in the docker env, which I missed in the original release.