### PR TITLE
BUG Update openblas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+### Added
+
+
+### Package Updates
+- openblas 0.3.5 -> 0.3.6 (#68, #70)
+
+
 ## [5.0.0] - 2019-03-12
 ### Changed
 - Ubuntu 14.04 -> 18.04 (#67)

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
 - nose=1.3.7
 - numexpr=2.6.9
 - numpy=1.16.2
-- openblas=0.3.5
+- openblas=0.3.6
 - pandas=0.24.1
 - patsy=0.5.1
 - psycopg2=2.7.7


### PR DESCRIPTION
Openblas v0.3.5 was removed from conda-forge because it was incompatible with Intel Skylake X CPUs. Update to the most recent release, v0.3.6.

Closes #68 .