### PR TITLE
[PARO-734] Bump versions of modeling packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 ## Unreleased
 ### Changed
 - Python 3.7.1 -> 3.7.6
+- Conda 4.6.8 -> 4.8.1
 
 ### Package Updates
 - openblas 0.3.5 -> 0.3.6 (#68, #70)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 - cloudpickle 0.8.0 -> 1.2.2
 - joblib 0.11.0 -> 0.14.1
 - muffnn 2.2.0 -> 2.3.0
+- nomkl 1.0 -> 3.0
 - numpy 1.16.2 -> 1.17.3
 - pandas 0.24.1 -> 0.25.3
 - pyarrow 0.12.1 -> 0.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,24 @@ Version number changes (major.minor.micro) in this package denote the following:
 - A major version will increase if there are any backwards-incompatible changes in any of the packages contained in this Docker image, or any other backwards-incompatible changes in the execution environment.
 
 ## Unreleased
-
-### Added
-- added buildspecs for autobuilding and pushing Docker image to Amazon ECR 
+### Changed
+- Python 3.7.1 -> 3.7.6
 
 ### Package Updates
 - openblas 0.3.5 -> 0.3.6 (#68, #70)
+- civis 1.9.4 -> 1.12.0 (#74, same for packages below)
+- civisml-extensions 0.1.10 -> 0.2.1
+- cloudpickle 0.8.0 -> 1.2.2
+- joblib 0.11.0 -> 0.14.1
+- muffnn 2.2.0 -> 2.3.0
+- numpy 1.16.2 -> 1.17.3
+- pandas 0.24.1 -> 0.25.3
+- pyarrow 0.12.1 -> 0.15.1
+- scipy 1.2.0 -> 1.4.1
+- scikit-learn 0.19.2 -> 0.22.1
 
+### Added
+- added buildspecs for autobuilding and pushing Docker image to Amazon ECR (#69)
 
 ## [5.0.0] - 2019-03-12
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV LANG=en_US.UTF-8 \
     BASH_ENV=/etc/profile \
     PATH=/opt/conda/bin:$PATH \
     CIVIS_MINICONDA_VERSION=4.5.12 \
-    CIVIS_CONDA_VERSION=4.6.8 \
+    CIVIS_CONDA_VERSION=4.8.1 \
     CIVIS_PYTHON_VERSION=3.7.6
 
 # Conda install.

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV LANG=en_US.UTF-8 \
     PATH=/opt/conda/bin:$PATH \
     CIVIS_MINICONDA_VERSION=4.5.12 \
     CIVIS_CONDA_VERSION=4.6.8 \
-    CIVIS_PYTHON_VERSION=3.7.1
+    CIVIS_PYTHON_VERSION=3.7.6
 
 # Conda install.
 #

--- a/environment.yml
+++ b/environment.yml
@@ -10,13 +10,15 @@ dependencies:
 - boto3=1.9.111
 - bqplot=0.11.5
 - click=6.7
-- cloudpickle=0.8.0
+- cloudpickle=1.2.2
 - cython=0.29.6
 - dask=1.1.4
 - feather-format=0.4.0
+- glmnet=2.1.1
 - ipython=7.3.0
 - ipywidgets=7.4.2
 - jinja2=2.10
+- joblib=0.14.1
 - jsonschema=3.0.1
 - jupyter=1.0.0
 - libffi=3.2.1
@@ -28,12 +30,12 @@ dependencies:
 - notebook=5.7.5
 - nose=1.3.7
 - numexpr=2.6.9
-- numpy=1.16.2
+- numpy=1.17.3
 - openblas=0.3.6
-- pandas=0.24.1
+- pandas=0.25.3
 - patsy=0.5.1
 - psycopg2=2.7.7
-- pyarrow=0.12.1
+- pyarrow=0.15.1
 - pycrypto=2.6.1
 - pytest=4.3.0
 - python=3.7.1
@@ -41,19 +43,17 @@ dependencies:
 - requests=2.21.0
 - s3fs=0.2.0
 - seaborn=0.9.0
-- scipy=1.2.0
-- scikit-learn=0.19.2
+- scipy=1.4.1
+- scikit-learn=0.22.1
 - statsmodels=0.9.0
 - urllib3=1.24.1
 - xgboost=0.81
 - pip:
-  - civis==1.9.4
-  - civisml-extensions==0.1.10
+  - civis==1.12.0
+  - civisml-extensions==0.2.1
   - dropbox==9.3.0
   - ftputil==3.4
-  - glmnet==2.1.1
-  - joblib==0.11.0
-  - muffnn==2.2.0
+  - muffnn==2.3.0
   - pubnub==4.1.2
   - pysftp==0.2.9
   - python-simple-hipchat==0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -38,7 +38,7 @@ dependencies:
 - pyarrow=0.15.1
 - pycrypto=2.6.1
 - pytest=4.3.0
-- python=3.7.1
+- python=3.7.6
 - pyyaml=3.13
 - requests=2.21.0
 - s3fs=0.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
 - libtiff=4.0.10
 - libxml2=2.9.8
 - matplotlib=3.0.3
-- nomkl=1.0
+- nomkl=3.0
 - notebook=5.7.5
 - nose=1.3.7
 - numexpr=2.6.9


### PR DESCRIPTION
This PR updates the versions of the Python data science modeling packages. I confirm that these changes will be good for the upcoming CivisML updates.

I think these package version changes together would constitute a minor version bump of the datascience-python Docker image, though I haven't updated the version number in this PR, which I leave to the current maintainers of this repo (e.g., in case there are other upcoming changes from other teams).