### PR TITLE
update civis-python, muffnn, and tensorflow. prep for 6.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [6.2.0]
+### Package Updates
+- civis 1.13.0 -> 1.14.0 (#77)
+- muffnn 2.3.0 -> 2.3.1 (#77)
+- tensorflow 1.13.1 -> 1.15.2 (#77)
+
 ## [6.1.0]
 ### Package Updates
 - civis 1.12.1 -> 1.13.0 (#76)

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN jupyter nbextension enable --py widgetsnbextension
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=6.1.0 \
+ENV VERSION=6.2.0 \
     VERSION_MAJOR=6 \
-    VERSION_MINOR=1 \
+    VERSION_MINOR=2 \
     VERSION_MICRO=0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/civisanalytics/datascience-python/tree/master.svg?style=svg)](https://circleci.com/gh/civisanalytics/datascience-python/tree/master)
 
-This image is created from the official Ubuntu 14.04 Docker image and contains popular Python packages for data science.
+This image is created from the official Ubuntu 18.04 Docker image and contains popular Python packages for data science.
 
 If you are reading this README on DockerHub, then the links to files in the GitHub respository will be broken. Please read this documentation from [GitHub](https://github.com/civisanalytics/datascience-python) instead.
 

--- a/environment.yml
+++ b/environment.yml
@@ -50,12 +50,12 @@ dependencies:
 - urllib3=1.25.7
 - xgboost=0.81
 - pip:
-  - civis==1.13.0
+  - civis==1.14.0
   - civisml-extensions==0.2.1
   - dropbox==9.4.0
   - ftputil==3.4
-  - muffnn==2.3.0
+  - muffnn==2.3.1
   - pubnub==4.3.0
   - pysftp==0.2.9
   - requests-toolbelt==0.9.1
-  - tensorflow==1.13.1
+  - tensorflow==1.15.2


### PR DESCRIPTION
related to https://github.com/civisanalytics/civis-python/pull/383 and https://github.com/civisanalytics/muffnn/pull/101