### PR TITLE
bump civis-python to 1.14.1, bump version to 6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [6.2.1]
+### Package Updates
+- civis 1.14.0 -> 1.14.1 (#78)
+
 ## [6.2.0]
 ### Package Updates
 - civis 1.13.0 -> 1.14.0 (#77)

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN jupyter nbextension enable --py widgetsnbextension
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=6.2.0 \
+ENV VERSION=6.2.1 \
     VERSION_MAJOR=6 \
     VERSION_MINOR=2 \
-    VERSION_MICRO=0
+    VERSION_MICRO=1

--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,7 @@ dependencies:
 - urllib3=1.25.7
 - xgboost=0.81
 - pip:
-  - civis==1.14.0
+  - civis==1.14.1
   - civisml-extensions==0.2.1
   - dropbox==9.4.0
   - ftputil==3.4


### PR DESCRIPTION
related to https://github.com/civisanalytics/civis-python/pull/385 and https://github.com/civisanalytics/civis-python/pull/384

here's a similar PR for a previous version, for comparison: https://github.com/civisanalytics/datascience-python/pull/77