### PR TITLE
update civis to 1.15.0 and prep release 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [6.3.0]
+### Package Updates
+- civis 1.14.0 -> 1.15.0 (#78)
+- tensorflow 1.15.2 -> 1.15.4 (#78)
+
 ## [6.2.1]
 ### Package Updates
 - civis 1.14.0 -> 1.14.1 (#78)

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN jupyter nbextension enable --py widgetsnbextension
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=6.2.1 \
+ENV VERSION=6.3.0 \
     VERSION_MAJOR=6 \
-    VERSION_MINOR=2 \
-    VERSION_MICRO=1
+    VERSION_MINOR=3 \
+    VERSION_MICRO=0

--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,7 @@ dependencies:
 - urllib3=1.25.7
 - xgboost=0.81
 - pip:
-  - civis==1.14.1
+  - civis==1.15.0
   - civisml-extensions==0.2.1
   - dropbox==9.4.0
   - ftputil==3.4
@@ -58,4 +58,4 @@ dependencies:
   - pubnub==4.3.0
   - pysftp==0.2.9
   - requests-toolbelt==0.9.1
-  - tensorflow==1.15.2
+  - tensorflow==1.15.4


### PR DESCRIPTION
also update tensorflow to 1.15.4 (cf. https://github.com/advisories/GHSA-4g9f-63rx-5cw4)