### PR TITLE
[CIVP-24102] upgrade pyyaml to 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## [6.4.0]
 ### Package Updates
-- PyYAML 3.13 -> 5.4.1
+- PyYAML 3.13 -> 5.2.0
 
 ## [6.3.1]
 ### Package Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [6.4.0]
+### Package Updates
+- PyYAML 3.13 -> 5.4.1
+
 ## [6.3.1]
 ### Package Updates
 - civis 1.15.0 -> 1.15.1 (#81)

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN jupyter nbextension enable --py widgetsnbextension
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=6.3.1 \
+ENV VERSION=6.4.0 \
     VERSION_MAJOR=6 \
-    VERSION_MINOR=3 \
-    VERSION_MICRO=1
+    VERSION_MINOR=4 \
+    VERSION_MICRO=0

--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,7 @@ dependencies:
 - pycrypto=2.6.1
 - pytest=5.3.5
 - python=3.7.6
-- pyyaml=3.13
+- pyyaml=5.2
 - requests=2.22.0
 - s3fs=0.4.0
 - seaborn=0.10.0


### PR DESCRIPTION
Updating pyyaml since a client needs a more recent version

console pr to update default tag:
https://github.com/civisanalytics/console/pull/15808