### PR TITLE
[CIVIS-1836] ENH upgrade civis-python to v1.16.0 and prepare for v6.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [6.5.0]
+### Package Updates
+- civis 1.15.1 -> 1.16.0 (#84)
+- Removed pubnub - not considered a breaking change, as it was a dependency for `civis` (#84)
+
 ## [6.4.0]
 ### Package Updates
 - PyYAML 3.13 -> 5.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN jupyter nbextension enable --py widgetsnbextension
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=6.4.0 \
+ENV VERSION=6.5.0 \
     VERSION_MAJOR=6 \
-    VERSION_MINOR=4 \
+    VERSION_MINOR=5 \
     VERSION_MICRO=0

--- a/environment.yml
+++ b/environment.yml
@@ -50,12 +50,11 @@ dependencies:
 - urllib3=1.25.7
 - xgboost=0.81
 - pip:
-  - civis==1.15.1
+  - git+https://github.com/civisanalytics/civis-python.git@civis-1835-v1.16.0-release#egg=civis
   - civisml-extensions==0.2.1
   - dropbox==9.4.0
   - ftputil==3.4
   - muffnn==2.3.1
-  - pubnub==4.3.0
   - pysftp==0.2.9
   - requests-toolbelt==0.9.1
   - tensorflow==1.15.4

--- a/environment.yml
+++ b/environment.yml
@@ -50,7 +50,7 @@ dependencies:
 - urllib3=1.25.7
 - xgboost=0.81
 - pip:
-  - git+https://github.com/civisanalytics/civis-python.git@civis-1835-v1.16.0-release#egg=civis
+  - civis==1.16.0
   - civisml-extensions==0.2.1
   - dropbox==9.4.0
   - ftputil==3.4


### PR DESCRIPTION
This PR updates the Civis API Python client to v1.16.0 and the datascience-python Docker image to v6.5.0.

TODOs:

- [x] Merge https://github.com/civisanalytics/civis-python/pull/448
- [x] The Python package `civis` v1.16.0 is available on PyPI for pip-installing.
- [x] Once the previous step is done, change the source of the `civis` from a GitHub branch to the PyPI source, i.e., `civis==1.16.0`
- [x] Update datascience-python version to v6.5.0 in this repo
- [x] Update changelog