### PR TITLE
[CIVIS-1912] FIX pin cffi at 1.14.0; prepare for 6.5.1 bug fix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [6.5.1]
+### Package Updates
+- Pin cffi at 1.14.0 (#85)
+
 ## [6.5.0]
 ### Package Updates
 - civis 1.15.1 -> 1.16.0 (#84)

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
 - boto=2.49.0
 - boto3=1.11.15
 - bqplot=0.12.3
+- cffi=1.14.0
 - click=6.7
 - cloudpickle=1.2.2
 - cython=0.29.15


### PR DESCRIPTION
This PR pins cffi at 1.14.0. The v6.5.0 image has cffi 1.15.0, and when one does `import bcrypt` it'd crash with `ImportError: libffi.so.7: cannot open shared object file: No such file or directory`. Downgrading cffi to 1.14.0 (= what the v6.4.0 was using) apparently would resolve the issue.