### PR TITLE
[CIVIS-6103] Python 3.11.4 Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.0
+      - image: cimg/python:3.11.4
     steps:
       - checkout
       - setup_remote_docker

--- a/.condarc
+++ b/.condarc
@@ -1,5 +1,6 @@
 channels:
     - defaults
+    - conda-forge
 
 show_channel_urls: True
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV LANG=en_US.UTF-8 \
     PATH=/opt/conda/bin:$PATH \
     MINICONDA_VERSION=23.3.1 \
     CONDA_VERSION=23.5.0 \
-    PYTHON_VERSION=3.8
+    PYTHON_VERSION=3.11.4
 
 # Conda install.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ ENV LANG=en_US.UTF-8 \
     CONDARC=/opt/conda/.condarc \
     BASH_ENV=/etc/profile \
     PATH=/opt/conda/bin:$PATH \
-    MINICONDA_VERSION=23.3.1-0 \
+    MINICONDA_VERSION=23.3.1 \
     CONDA_VERSION=23.5.0 \
-    PYTHON_VERSION=3.11.4
+    PYTHON_VERSION=3.8
 
 # Conda install.
 #
@@ -61,9 +61,9 @@ ENV LANG=en_US.UTF-8 \
 #   Red Hat and Debian use different names for this file. git2R wants the latter.
 #   See conda-recipes GH 423
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py310_${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    /bin/bash /Miniconda3-py310_${MINICONDA_VERSION}-Linux-x86_64.sh -b -p /opt/conda && \
-    rm Miniconda3-py310_${MINICONDA_VERSION}-Linux-x86_64.sh
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py310_${MINICONDA_VERSION}-0-Linux-x86_64.sh && \
+    /bin/bash /Miniconda3-py310_${MINICONDA_VERSION}-0-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniconda3-py310_${MINICONDA_VERSION}-0-Linux-x86_64.sh
 
 RUN /opt/conda/bin/conda install --yes conda==${CONDA_VERSION} && \
     conda install conda=${CONDA_VERSION} && \
@@ -76,13 +76,17 @@ RUN /opt/conda/bin/conda install --yes conda==${CONDA_VERSION} && \
 RUN ln -s /opt/conda/lib/libopenblas.so /opt/conda/lib/libblas.so && \
     ln -s /opt/conda/lib/libopenblas.so /opt/conda/lib/liblapack.so && \
     ln -s /opt/conda/lib/libssl.so /opt/conda/lib/libssl.so.6 && \
-    ln -s /opt/conda/lib/libcrypto.so /opt/conda/lib/libcrypto.so.6
+    ln -s /opt/conda/lib/libcrypto.so /opt/conda/lib/libcrypto.so.6 && \
+    ln -s /opt/conda/lib/libarchive.so /opt/conda/lib/libarchive.so.19
+
+COPY .condarc /opt/conda/.condarc
+COPY environment.yml environment.yml
 
 # Install boto in the base environment for private s3 channel support.
 # Install Python Packages
-COPY .condarc /opt/conda/.condarc
-COPY environment.yml environment.yml
-RUN conda install -y boto && \
+RUN conda install -n base conda-libmamba-solver && \
+    conda config --set solver libmamba && \
+    conda install -y boto && \
     conda install -y nomkl && \
     conda env update -f environment.yml -n root && \
     conda clean --all -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-MAINTAINER support@civisanalytics.com
+LABEL maintainer="support@civisanalytics.com"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
   apt-get install -y --no-install-recommends locales && \
@@ -29,9 +29,9 @@ ENV LANG=en_US.UTF-8 \
     CONDARC=/opt/conda/.condarc \
     BASH_ENV=/etc/profile \
     PATH=/opt/conda/bin:$PATH \
-    CIVIS_MINICONDA_VERSION=4.5.12 \
-    CIVIS_CONDA_VERSION=4.8.1 \
-    CIVIS_PYTHON_VERSION=3.7.6
+    MINICONDA_VERSION=23.3.1-0 \
+    CONDA_VERSION=23.5.0 \
+    PYTHON_VERSION=3.11.4
 
 # Conda install.
 #
@@ -44,7 +44,7 @@ ENV LANG=en_US.UTF-8 \
 # resolve dependencies relative to a fixed conda & python version.
 #
 # Note that the python version is also listed in the environment.yml
-# file. The version in CIVIS_PYTHON_VERSION is the source of truth.
+# file. The version in PYTHON_VERSION is the source of truth.
 # If you want to change the python version, you need to change it in
 # **both** places. The python version has been left in the `environment.yml`
 # file so that people can create environments equivalent to this
@@ -52,25 +52,28 @@ ENV LANG=en_US.UTF-8 \
 #
 # The ordering of these steps seems to matter. You seem to have to
 # install a specific python version by hand and then pin it.
-# 1) install conda using CIVIS_MINICONDA_VERSION (may not be most up to date conda version)
-# 2) pin conda to the version given by CIVIS_CONDA_VERSION
-# 3) install the python version CIVIS_PYTHON_VERSION
+# 1) install conda using MINICONDA_VERSION (may not be most up to date conda version)
+# 2) pin conda to the version given by CONDA_VERSION
+# 3) install the python version PYTHON_VERSION
 # 4) pin the python version
 #
 # Extra symlinks are added at the end because...
 #   Red Hat and Debian use different names for this file. git2R wants the latter.
 #   See conda-recipes GH 423
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${CIVIS_MINICONDA_VERSION}-Linux-x86_64.sh && \
-    /bin/bash /Miniconda3-${CIVIS_MINICONDA_VERSION}-Linux-x86_64.sh -b -p /opt/conda && \
-    rm Miniconda3-${CIVIS_MINICONDA_VERSION}-Linux-x86_64.sh && \
-    /opt/conda/bin/conda install --yes conda==${CIVIS_MINICONDA_VERSION} && \
-    conda install conda=${CIVIS_CONDA_VERSION} && \
-    echo "conda ==${CIVIS_CONDA_VERSION}" > /opt/conda/conda-meta/pinned && \
-    conda install --yes python==${CIVIS_PYTHON_VERSION} && \
-    echo "python ==${CIVIS_PYTHON_VERSION}" >> /opt/conda/conda-meta/pinned && \
-    conda clean --all -y && \
-    ln -s /opt/conda/lib/libopenblas.so /opt/conda/lib/libblas.so && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py310_${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    /bin/bash /Miniconda3-py310_${MINICONDA_VERSION}-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniconda3-py310_${MINICONDA_VERSION}-Linux-x86_64.sh
+
+RUN /opt/conda/bin/conda install --yes conda==${CONDA_VERSION} && \
+    conda install conda=${CONDA_VERSION} && \
+    echo "conda ==${CONDA_VERSION}" > /opt/conda/conda-meta/pinned && \
+    conda config --append channels conda-forge && \
+    conda install --yes python==${PYTHON_VERSION} && \
+    echo "python ==${PYTHON_VERSION}" >> /opt/conda/conda-meta/pinned && \
+    conda clean --all -y
+
+RUN ln -s /opt/conda/lib/libopenblas.so /opt/conda/lib/libblas.so && \
     ln -s /opt/conda/lib/libopenblas.so /opt/conda/lib/liblapack.so && \
     ln -s /opt/conda/lib/libssl.so /opt/conda/lib/libssl.so.6 && \
     ln -s /opt/conda/lib/libcrypto.so /opt/conda/lib/libcrypto.so.6
@@ -106,7 +109,7 @@ RUN jupyter nbextension enable --py widgetsnbextension
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=6.5.0 \
+ENV VERSION=6.6.0 \
     VERSION_MAJOR=6 \
-    VERSION_MINOR=5 \
+    VERSION_MINOR=6 \
     VERSION_MICRO=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 
 RUN /opt/conda/bin/conda install --yes conda==${CONDA_VERSION} && \
     conda install conda=${CONDA_VERSION} && \
+    conda config --set channel_priority strict && \
     echo "conda ==${CONDA_VERSION}" > /opt/conda/conda-meta/pinned && \
     conda config --append channels conda-forge && \
     conda install --yes python==${PYTHON_VERSION} && \
@@ -84,7 +85,8 @@ COPY environment.yml environment.yml
 
 # Install boto in the base environment for private s3 channel support.
 # Install Python Packages
-RUN conda install -n base conda-libmamba-solver && \
+RUN conda config --set channel_priority strict && \
+    conda install -n base conda-libmamba-solver && \
     conda config --set solver libmamba && \
     conda install -y boto && \
     conda install -y nomkl && \

--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,7 @@ dependencies:
 - pyarrow=0.16.0
 - pycrypto=2.6.1
 - pytest=5.3.5
-- python=3.7.6
+- python=3.11.4
 - pyyaml=5.2
 - requests=2.22.0
 - s3fs=0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,16 +3,17 @@ channels:
 - defaults
 - conda-forge
 dependencies:
-- conda==23.5.0
 - awscli=1.17.15
 - beautifulsoup4=4.8.2
 - botocore=1.14.15
 - boto=2.49.0
 - boto3=1.11.15
+- blas=1.0
 - bqplot=0.12.3
 - cffi=1.14.0
 - click=6.7
 - cloudpickle=1.2.2
+- conda-libmamba-solver=23.5.0
 - cython=0.29.15
 - dask=2.10.1
 - feather-format=0.4.0
@@ -34,7 +35,6 @@ dependencies:
 - numexpr=2.7.1
 - numpy=1.17.3
 - openblas=0.3.6
-- blas=1.0
 - pandas=0.25.3
 - patsy=0.5.1
 - pip=23.1.2
@@ -42,7 +42,7 @@ dependencies:
 - pyarrow=0.16.0
 - pycrypto=2.6.1
 - pytest=5.3.5
-- python=3.9.17
+- python=3.11.4
 - pyyaml=5.2
 - requests=2.22.0
 - s3fs=0.4.0
@@ -52,7 +52,6 @@ dependencies:
 - statsmodels=0.11.0
 - urllib3=1.25.7
 - xgboost=0.81
-- conda-libmamba-solver=23.5.0
 - pip:
   - civis==1.16.0
   - civisml-extensions==0.2.1

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
 - defaults
 - conda-forge
 dependencies:
+- conda==23.5.0
 - awscli=1.17.15
 - beautifulsoup4=4.8.2
 - botocore=1.14.15
@@ -33,14 +34,15 @@ dependencies:
 - numexpr=2.7.1
 - numpy=1.17.3
 - openblas=0.3.6
+- blas=1.0
 - pandas=0.25.3
 - patsy=0.5.1
-- pip=20.0.2
+- pip=23.1.2
 - psycopg2=2.8.4
 - pyarrow=0.16.0
 - pycrypto=2.6.1
 - pytest=5.3.5
-- python=3.11.4
+- python=3.9.17
 - pyyaml=5.2
 - requests=2.22.0
 - s3fs=0.4.0
@@ -50,6 +52,7 @@ dependencies:
 - statsmodels=0.11.0
 - urllib3=1.25.7
 - xgboost=0.81
+- conda-libmamba-solver=23.5.0
 - pip:
   - civis==1.16.0
   - civisml-extensions==0.2.1
@@ -58,4 +61,4 @@ dependencies:
   - muffnn==2.3.1
   - pysftp==0.2.9
   - requests-toolbelt==0.9.1
-  - tensorflow==1.15.4
+  - tensorflow==1.15.5


### PR DESCRIPTION
* updates python to v3.11.4
* updates miniconda to 23.3.1 - used to install the latest version of conda
* updates conda to 23.5.0 - supports python 3.11.4
