### PR TITLE
[CIVIS-6103] Update Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV LANG=en_US.UTF-8 \
     PATH=/opt/conda/bin:$PATH \
     CIVIS_MINICONDA_VERSION=4.5.12 \
     CIVIS_CONDA_VERSION=4.8.1 \
-    CIVIS_PYTHON_VERSION=3.7.6
+    CIVIS_PYTHON_VERSION=3.8.15
 
 # Conda install.
 #

--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,7 @@ dependencies:
 - pyarrow=0.16.0
 - pycrypto=2.6.1
 - pytest=5.3.5
-- python=3.7.6
+- python=3.8.15
 - pyyaml=5.2
 - requests=2.22.0
 - s3fs=0.4.0


### PR DESCRIPTION
python 3.7 is EOL.
this updates to 3.8. tried updating to 3.11, 3.10, and 3.9. These were far from trivial. 
Going to push out this change to get us back into a supported version.
I will spend some time trying to update to a version >3.8. if i don't succeed within a reasonable timebox of 0.5 day to 1 day, i'll create a follow up ticket. 


tried 3.11.4 in this PR https://github.com/civisanalytics/datascience-python/pull/87