### PR TITLE
[CIVIS-8784] ENH update dependency versions: civis-python v2.3.0, python v3.12.4

### DIFF
--- a/.circleci/test_image.py
+++ b/.circleci/test_image.py
@@ -29,8 +29,18 @@ class TestImage(unittest.TestCase):
     def test_numpy_can_import(self):
         import numpy as np  # noqa: F401
 
+    def test_sklearn_can_import(self):
+        import sklearn  # noqa: F401
+
     def test_civis_can_import(self):
         import civis  # noqa: F401
+        # civis-python uses lazy imports since v2.3.0,
+        # so try to import the top-level modules.
+        import civis.io  # noqa: F401
+        import civis.parallel  # noqa: F401
+        import civis.futures  # noqa: F401
+        import civis.ml  # noqa: F401
+        import civis.utils  # noqa: F401
 
 
 if __name__ == "__main__":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [7.3.0]
+- Core dependencies updated to latest versions:
+  * awscli 1.32.112 -> 1.33.9
+  * boto3 1.34.112 -> 1.34.127
+  * civis 2.1.0 -> 2.3.0
+  * numpy 1.26.4 -> 2.0.0
+  * requests 2.32.2 -> 2.32.3
+
 ## [7.2.0]
 - Core dependencies updated to latest versions:
   * awscli 1.32.109 -> 1.32.112

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Version number changes (major.minor.micro) in this package denote the following:
   * civis 2.1.0 -> 2.3.0
   * numpy 1.26.4 -> 2.0.0
   * requests 2.32.2 -> 2.32.3
+- Python version updated to v3.12.4
 
 ## [7.2.0]
 - Core dependencies updated to latest versions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
 
 COPY requirements-full.txt .
 
-RUN pip install -r requirements-full.txt && \
-  pip cache purge && \
+RUN pip install --progress-bar off --no-cache-dir -r requirements-full.txt && \
   rm requirements-full.txt
 
 # Instruct joblib to use disk for temporary files. Joblib defaults to
@@ -35,9 +34,9 @@ RUN pip install -r requirements-full.txt && \
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=7.2.0 \
+ENV VERSION=7.3.0 \
   VERSION_MAJOR=7 \
-  VERSION_MINOR=2 \
+  VERSION_MINOR=3 \
   VERSION_MICRO=0
 
 FROM production AS test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.3-slim AS production
+FROM python:3.12.4-slim AS production
 
 LABEL maintainer = support@civisanalytics.com
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,8 +1,8 @@
-awscli==1.32.112
-boto3==1.34.112
-civis==2.1.0
-numpy==1.26.4
+awscli==1.33.9
+boto3==1.34.127
+civis==2.3.0
+numpy==2.0.0
 pandas==2.2.2
-requests==2.32.2
+requests==2.32.3
 scikit-learn==1.5.0
 scipy==1.13.1

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -8,20 +8,20 @@ attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
-awscli==1.32.112
+awscli==1.33.9
     # via -r requirements-core.txt
-boto3==1.34.112
+boto3==1.34.127
     # via -r requirements-core.txt
-botocore==1.34.112
+botocore==1.34.127
     # via
     #   awscli
     #   boto3
     #   s3transfer
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
-civis==2.1.0
+civis==2.3.0
     # via -r requirements-core.txt
 click==8.1.7
     # via civis
@@ -37,7 +37,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joblib==1.2.0
+joblib==1.4.2
     # via
     #   civis
     #   scikit-learn
@@ -47,7 +47,7 @@ jsonschema==4.22.0
     # via civis
 jsonschema-specifications==2023.12.1
     # via jsonschema
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   -r requirements-core.txt
     #   pandas
@@ -71,7 +71,7 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.2
+requests==2.32.3
     # via
     #   -r requirements-core.txt
     #   civis
@@ -93,13 +93,13 @@ scipy==1.13.1
     #   scikit-learn
 six==1.16.0
     # via python-dateutil
-tenacity==8.3.0
+tenacity==8.4.1
     # via civis
 threadpoolctl==3.5.0
     # via scikit-learn
 tzdata==2024.1
     # via pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
This pull request updates the civis-python version to v2.3.0. Also updated are Python to v3.12.4 as well as other core dependencies that have an updated version.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
