### PR TITLE
[CIVIS-9315] Update Python to 3.12.6, fix apt-get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [8.0.1]
+
+- Python version updated to v3.12.6
+
 ## [8.0.0]
 - Core dependencies updated to latest versions:
   * awscli 1.33.9 -> 2.17.37

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,10 @@ RUN pip install --progress-bar off --no-cache-dir -r requirements-full.txt && \
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=8.0.0 \
+ENV VERSION=8.0.1 \
   VERSION_MAJOR=8 \
   VERSION_MINOR=0 \
-  VERSION_MICRO=0
+  VERSION_MICRO=1
 
 # Install the AWSCLI for moving match targets in the QC workflow.
 # See https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#cliv2-linux-install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM=linux/x86_64
-ARG BASE_IMAGE=python:3.12.5-slim
+ARG BASE_IMAGE=python:3.12.6-slim
 
 # This is the primary build target used for the production image
 FROM --platform=$PLATFORM $BASE_IMAGE AS production

--- a/buildspec/push.yaml
+++ b/buildspec/push.yaml
@@ -12,7 +12,7 @@ phases:
       - docker build --tag ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT} --tag ${FIPS_REPOSITORY_URI}:${BRANCH_NAME} .
       # This config tests the codebuild login and the build but does not push dev images.
       # The following lines can be temporarily uncommented to test a dev image.
-      - docker image push --all-tags ${FIPS_REPOSITORY_URI}
+      # - docker image push --all-tags ${FIPS_REPOSITORY_URI}
   post_build:
     commands:
       - echo Build completed!

--- a/buildspec/push.yaml
+++ b/buildspec/push.yaml
@@ -12,7 +12,7 @@ phases:
       - docker build --tag ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT} --tag ${FIPS_REPOSITORY_URI}:${BRANCH_NAME} .
       # This config tests the codebuild login and the build but does not push dev images.
       # The following lines can be temporarily uncommented to test a dev image.
-      # - docker image push --all-tags ${FIPS_REPOSITORY_URI}
+      - docker image push --all-tags ${FIPS_REPOSITORY_URI}
   post_build:
     commands:
       - echo Build completed!


### PR DESCRIPTION
This updates the base image to `python:3.12.6-slim`. Rebuilding the image seems to fix issues with `apt-get` that appeared again some time after #97, and it seemed good to go ahead and update the Python version to make a new release.

[Here's](https://platform.civisanalytics.com/spa/#/scripts/containers/286557987) an internal test job using the tag from this branch, showing that `apt-get update` works. For comparison, [here's](https://platform.civisanalytics.com/spa/#/scripts/containers/286558174) a job using the 8.0.0 tag. 

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
