### PR TITLE
[CIVIS-10059] ENH update civis-python to v2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [8.2.0]
+
+- Python version updated: 3.12.7 -> 3.12.8
+- uv version updated: 0.5.1 -> 0.5.18
+- Core dependencies updated to latest versions:
+  * awscli 2.19.5 -> 2.22.33
+  * boto3 1.35.58 -> 1.35.97
+  * civis 2.4.0 -> 2.4.3
+  * numpy 2.1.3 -> 2.2.1
+  * scikit-learn 1.5.2 -> 1.6.1
+  * scipy 1.14.1 -> 1.15.1
+
 ## [8.1.0]
 
 - Python version updated to v3.12.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM=linux/x86_64
-ARG BASE_IMAGE=python:3.12.7-slim
+ARG BASE_IMAGE=python:3.12.8-slim
 
 # This is the primary build target used for the production image
 FROM --platform=$PLATFORM $BASE_IMAGE AS production
@@ -38,7 +38,7 @@ RUN pip install --progress-bar off --no-cache-dir -r requirements-full.txt && \
   rm requirements-full.txt
 
 # Install uv.
-ADD https://astral.sh/uv/0.5.1/install.sh /uv-installer.sh
+ADD https://astral.sh/uv/0.5.18/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH" \
   UV_SYSTEM_PYTHON=1
@@ -49,9 +49,9 @@ ENV PATH="/root/.local/bin/:$PATH" \
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=8.1.0 \
+ENV VERSION=8.2.0 \
   VERSION_MAJOR=8 \
-  VERSION_MINOR=1 \
+  VERSION_MINOR=2 \
   VERSION_MICRO=0
 
 # This build target is for testing in CircleCI.

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,11 +1,11 @@
 # awscli v2 is not officially available on PyPI (https://github.com/aws/aws-cli/issues/4947).
 # Specifying awscli in requirements-core.txt here ensures that it (and its transitive dependencies)
 # are taken into account when generating the final requirements-full.txt file.
-awscli @ git+https://github.com/aws/aws-cli@2.19.5
-boto3==1.35.58
-civis==2.4.0
-numpy==2.1.3
+awscli @ git+https://github.com/aws/aws-cli@2.22.33
+boto3==1.35.97
+civis==2.4.3
+numpy==2.2.1
 pandas==2.2.3
 requests==2.32.3
-scikit-learn==1.5.2
-scipy==1.14.1
+scikit-learn==1.6.1
+scipy==1.15.1

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -4,29 +4,29 @@
 #
 #    pip-compile --output-file=requirements-full.txt --pip-args='--prefer-binary' --strip-extras requirements-core.txt
 #
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   jsonschema
     #   referencing
-awscli @ git+https://github.com/aws/aws-cli@2.19.5
+awscli @ git+https://github.com/aws/aws-cli@2.22.33
     # via -r requirements-core.txt
-awscrt==0.22.0
+awscrt==0.23.4
     # via awscli
-boto3==1.35.58
+boto3==1.35.97
     # via -r requirements-core.txt
-botocore==1.35.58
+botocore==1.35.97
     # via
     #   boto3
     #   s3transfer
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-civis==2.4.0
+civis==2.4.3
     # via -r requirements-core.txt
-click==8.1.7
+click==8.1.8
     # via civis
 cloudpickle==3.1.0
     # via civis
@@ -55,7 +55,7 @@ jsonschema==4.23.0
     # via civis
 jsonschema-specifications==2024.10.1
     # via jsonschema
-numpy==2.1.3
+numpy==2.2.1
     # via
     #   -r requirements-core.txt
     #   pandas
@@ -84,7 +84,7 @@ requests==2.32.3
     # via
     #   -r requirements-core.txt
     #   civis
-rpds-py==0.21.0
+rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
@@ -92,15 +92,15 @@ ruamel-yaml==0.17.21
     # via awscli
 ruamel-yaml-clib==0.2.8
     # via awscli
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via boto3
-scikit-learn==1.5.2
+scikit-learn==1.6.1
     # via -r requirements-core.txt
-scipy==1.14.1
+scipy==1.15.1
     # via
     #   -r requirements-core.txt
     #   scikit-learn
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 tenacity==9.0.0
     # via civis
@@ -115,3 +115,5 @@ urllib3==1.26.20
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
+zipp==3.20.2
+    # via awscli


### PR DESCRIPTION
This pull request updates the civis-python library shipped in the datascience-python image to the latest bugfix version v2.4.3 (https://github.com/civisanalytics/civis-python/pull/507). Also updating other core dependencies.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
