### PR TITLE
[CIVIS-13726] ENH Python 3.14 and Pandas 3.x; bump image version to 9.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/python:3.13
+      - image: cimg/python:3.14
     steps:
       - checkout
       - setup_remote_docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,20 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
-## [9.0.0] - 2026-07-xx
+## [9.0.0] - 2026-07-13
 
-- Python version updated: 3.13.13 -> 3.14.5
-- uv version updated: 0.11.8 -> 0.11.18
+- Python version updated: 3.13.13 -> 3.14.6
+- uv version updated: 0.11.8 -> 0.11.28
 - Core dependencies updated to latest versions:
-  * awscli 2.34.38 -> 2.34.58
-  * boto3 1.42.97 -> 1.43.19
-  * numpy 2.4.4 -> 2.4.6
+  * awscli 2.34.38 -> 2.35.21
+  * boto3 1.42.97 -> 1.43.46
+  * matplotlib 3.10.9 -> 3.11.0
+  * numpy 2.4.4 -> 2.5.1
   * pandas 2.3.3 -> 3.0.3
-  * polars 1.40.1 -> 1.41.2
+  * polars 1.40.1 -> 1.42.1
   * requests 2.33.1 -> 2.34.2
   * scikit-learn 1.8.0 -> 1.9.0
+  * scipy 1.17.1 -> 1.18.0
 
 ## [8.5.0] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [9.0.0] - 2026-07-xx
+
+- Python version updated: 3.13.13 -> 3.14.5
+- uv version updated: 0.11.8 -> 0.11.18
+- Core dependencies updated to latest versions:
+  * awscli 2.34.38 -> 2.34.58
+  * boto3 1.42.97 -> 1.43.19
+  * numpy 2.4.4 -> 2.4.6
+  * pandas 2.3.3 -> 3.0.3
+  * polars 1.40.1 -> 1.41.2
+  * requests 2.33.1 -> 2.34.2
+  * scikit-learn 1.8.0 -> 1.9.0
+
 ## [8.5.0] - 2026-05-04
 
 - Python version updated: 3.13.11 -> 3.13.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM=linux/x86_64
-ARG BASE_IMAGE=python:3.13.13-slim
+ARG BASE_IMAGE=python:3.14.5-slim
 
 FROM --platform=$PLATFORM $BASE_IMAGE AS uv-installed
 
@@ -31,7 +31,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
   rm -rf /var/lib/apt/lists/*
 
 # Install uv.
-ADD https://astral.sh/uv/0.11.8/install.sh /uv-installer.sh
+ADD https://astral.sh/uv/0.11.18/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH" \
   UV_SYSTEM_PYTHON=1
@@ -50,9 +50,9 @@ RUN uv pip install --no-progress --no-cache -r requirements-full.txt && \
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=8.5.0 \
-  VERSION_MAJOR=8 \
-  VERSION_MINOR=5 \
+ENV VERSION=9.0.0 \
+  VERSION_MAJOR=9 \
+  VERSION_MINOR=0 \
   VERSION_MICRO=0
 
 # This build target is for testing in CircleCI.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PLATFORM=linux/x86_64
-ARG BASE_IMAGE=python:3.14.5-slim
+ARG BASE_IMAGE=python:3.14.6-slim
 
 FROM --platform=$PLATFORM $BASE_IMAGE AS uv-installed
 
@@ -31,7 +31,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
   rm -rf /var/lib/apt/lists/*
 
 # Install uv.
-ADD https://astral.sh/uv/0.11.18/install.sh /uv-installer.sh
+ADD https://astral.sh/uv/0.11.28/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH" \
   UV_SYSTEM_PYTHON=1

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,14 +1,14 @@
 # awscli v2 is not officially available on PyPI (https://github.com/aws/aws-cli/issues/4947).
 # Specifying awscli in requirements-core.txt here ensures that it (and its transitive dependencies)
 # are taken into account when generating the final requirements-full.txt file.
-awscli @ git+https://github.com/aws/aws-cli@2.34.38
-boto3==1.42.97
+awscli @ git+https://github.com/aws/aws-cli@2.34.58
+boto3==1.43.19
 civis==2.9.1
 matplotlib==3.10.9
-numpy==2.4.4
-pandas==2.3.3
-polars==1.40.1
-requests==2.33.1
-scikit-learn==1.8.0
+numpy==2.4.6
+pandas==3.0.3
+polars==1.41.2
+requests==2.34.2
+scikit-learn==1.9.0
 scipy==1.17.1
 seaborn==0.13.2

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,14 +1,14 @@
 # awscli v2 is not officially available on PyPI (https://github.com/aws/aws-cli/issues/4947).
 # Specifying awscli in requirements-core.txt here ensures that it (and its transitive dependencies)
 # are taken into account when generating the final requirements-full.txt file.
-awscli @ git+https://github.com/aws/aws-cli@2.34.58
-boto3==1.43.19
+awscli @ git+https://github.com/aws/aws-cli@2.35.21
+boto3==1.43.46
 civis==2.9.1
-matplotlib==3.10.9
-numpy==2.4.6
+matplotlib==3.11.0
+numpy==2.5.1
 pandas==3.0.3
-polars==1.41.2
+polars==1.42.1
 requests==2.34.2
 scikit-learn==1.9.0
-scipy==1.17.1
+scipy==1.18.0
 seaborn==0.13.2

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -4,23 +4,23 @@ attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
-awscli @ git+https://github.com/aws/aws-cli@ffa4d0e80eef1bf2ca6e22fec595358210622148
+awscli @ git+https://github.com/aws/aws-cli@a40e66cbfe1f1890e3e8d95bc549cfd8f7f5e596
     # via -r requirements-core.txt
 awscrt==0.32.2
     # via awscli
-boto3==1.42.97
+boto3==1.43.19
     # via -r requirements-core.txt
-botocore==1.42.97
+botocore==1.43.19
     # via
     #   boto3
     #   s3transfer
-certifi==2026.4.22
+certifi==2026.5.20
     # via requests
 charset-normalizer==3.4.7
     # via requests
 civis==2.9.1
     # via -r requirements-core.txt
-click==8.3.3
+click==8.4.1
     # via civis
 cloudpickle==3.1.2
     # via civis
@@ -34,9 +34,9 @@ distro==1.8.0
     # via awscli
 docutils==0.19
     # via awscli
-fonttools==4.62.1
+fonttools==4.63.0
     # via matplotlib
-idna==3.13
+idna==3.18
     # via requests
 jmespath==1.0.1
     # via
@@ -59,7 +59,9 @@ matplotlib==3.10.9
     # via
     #   -r requirements-core.txt
     #   seaborn
-numpy==2.4.4
+narwhals==2.22.0
+    # via scikit-learn
+numpy==2.4.6
     # via
     #   -r requirements-core.txt
     #   contourpy
@@ -70,15 +72,15 @@ numpy==2.4.4
     #   seaborn
 packaging==26.2
     # via matplotlib
-pandas==2.3.3
+pandas==3.0.3
     # via
     #   -r requirements-core.txt
     #   seaborn
 pillow==12.2.0
     # via matplotlib
-polars==1.40.1
+polars==1.41.2
     # via -r requirements-core.txt
-polars-runtime-32==1.40.1
+polars-runtime-32==1.41.2
     # via polars
 prompt-toolkit==3.0.51
     # via awscli
@@ -90,19 +92,17 @@ python-dateutil==2.9.0
     #   botocore
     #   matplotlib
     #   pandas
-pytz==2026.1.post1
-    # via pandas
 pyyaml==6.0.3
     # via civis
 referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.33.1
+requests==2.34.2
     # via
     #   -r requirements-core.txt
     #   civis
-rpds-py==0.30.0
+rpds-py==2026.5.1
     # via
     #   jsonschema
     #   referencing
@@ -110,9 +110,9 @@ ruamel-yaml==0.19.1
     # via awscli
 ruamel-yaml-clib==0.2.15
     # via awscli
-s3transfer==0.16.1
+s3transfer==0.18.0
     # via boto3
-scikit-learn==1.8.0
+scikit-learn==1.9.0
     # via -r requirements-core.txt
 scipy==1.17.1
     # via
@@ -126,8 +126,6 @@ tenacity==9.1.4
     # via civis
 threadpoolctl==3.6.0
     # via scikit-learn
-tzdata==2026.2
-    # via pandas
 urllib3==2.6.3
     # via
     #   awscli

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -4,23 +4,23 @@ attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
-awscli @ git+https://github.com/aws/aws-cli@a40e66cbfe1f1890e3e8d95bc549cfd8f7f5e596
+awscli @ git+https://github.com/aws/aws-cli@305c68ef3fa68a15cdd8f50d9e7077c0e1ff8877
     # via -r requirements-core.txt
-awscrt==0.32.2
+awscrt==0.35.0
     # via awscli
-boto3==1.43.19
+boto3==1.43.46
     # via -r requirements-core.txt
-botocore==1.43.19
+botocore==1.43.46
     # via
     #   boto3
     #   s3transfer
-certifi==2026.5.20
+certifi==2026.6.17
     # via requests
-charset-normalizer==3.4.7
+charset-normalizer==3.4.9
     # via requests
 civis==2.9.1
     # via -r requirements-core.txt
-click==8.4.1
+click==8.4.2
     # via civis
 cloudpickle==3.1.2
     # via civis
@@ -55,13 +55,13 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 kiwisolver==1.5.0
     # via matplotlib
-matplotlib==3.10.9
+matplotlib==3.11.0
     # via
     #   -r requirements-core.txt
     #   seaborn
-narwhals==2.22.0
+narwhals==2.24.0
     # via scikit-learn
-numpy==2.4.6
+numpy==2.5.1
     # via
     #   -r requirements-core.txt
     #   contourpy
@@ -76,11 +76,11 @@ pandas==3.0.3
     # via
     #   -r requirements-core.txt
     #   seaborn
-pillow==12.2.0
+pillow==12.3.0
     # via matplotlib
-polars==1.41.2
+polars==1.42.1
     # via -r requirements-core.txt
-polars-runtime-32==1.41.2
+polars-runtime-32==1.42.1
     # via polars
 prompt-toolkit==3.0.51
     # via awscli
@@ -102,7 +102,7 @@ requests==2.34.2
     # via
     #   -r requirements-core.txt
     #   civis
-rpds-py==2026.5.1
+rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
@@ -110,11 +110,11 @@ ruamel-yaml==0.19.1
     # via awscli
 ruamel-yaml-clib==0.2.15
     # via awscli
-s3transfer==0.18.0
+s3transfer==0.19.1
     # via boto3
 scikit-learn==1.9.0
     # via -r requirements-core.txt
-scipy==1.17.1
+scipy==1.18.0
     # via
     #   -r requirements-core.txt
     #   scikit-learn


### PR DESCRIPTION
This is another round of updating the dependency versions in the image. Two version bumps with known breaking changes are Python 3.13 -> 3.14 and Pandas 2.x to 3.x, hence bumping the image version from 8.x to 9.0.0.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
