### PR TITLE
[CIVIS-14150] ENH civis-python 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Version number changes (major.minor.micro) in this package denote the following:
 
 ## Unreleased
 
+## [9.1.0] - 2026-09-11
+
+- uv version updated: 0.11.28 -> 0.12.13
+- Core dependencies updated to latest versions:
+  * awscli 2.35.21 -> 2.36.43
+  * boto3 1.43.46 -> 1.43.92
+  * civis 2.9.1 -> 2.10.0
+  * matplotlib 3.11.0 -> 3.11.1
+  * numpy 2.5.1 -> 2.5.3
+  * pandas 3.0.3 -> 3.0.5
+  * polars 1.42.1 -> 1.44.2
+  * scikit-learn 1.9.0 -> 1.9.1
+  * scipy 1.18.0 -> 1.18.1
+
 ## [9.0.0] - 2026-07-13
 
 - Python version updated: 3.13.13 -> 3.14.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && 
   rm -rf /var/lib/apt/lists/*
 
 # Install uv.
-ADD https://astral.sh/uv/0.11.28/install.sh /uv-installer.sh
+ADD https://astral.sh/uv/0.12.13/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH" \
   UV_SYSTEM_PYTHON=1
@@ -50,9 +50,9 @@ RUN uv pip install --no-progress --no-cache -r requirements-full.txt && \
 # https://github.com/joblib/joblib/blob/0.11/joblib/parallel.py#L328L342
 ENV JOBLIB_TEMP_FOLDER=/tmp
 
-ENV VERSION=9.0.0 \
+ENV VERSION=9.1.0 \
   VERSION_MAJOR=9 \
-  VERSION_MINOR=0 \
+  VERSION_MINOR=1 \
   VERSION_MICRO=0
 
 # This build target is for testing in CircleCI.

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,14 +1,14 @@
 # awscli v2 is not officially available on PyPI (https://github.com/aws/aws-cli/issues/4947).
 # Specifying awscli in requirements-core.txt here ensures that it (and its transitive dependencies)
 # are taken into account when generating the final requirements-full.txt file.
-awscli @ git+https://github.com/aws/aws-cli@2.35.21
-boto3==1.43.46
-civis==2.9.1
-matplotlib==3.11.0
-numpy==2.5.1
-pandas==3.0.3
-polars==1.42.1
+awscli @ git+https://github.com/aws/aws-cli@2.36.43
+boto3==1.43.92
+civis==2.10.0
+matplotlib==3.11.1
+numpy==2.5.3
+pandas==3.0.5
+polars==1.44.2
 requests==2.34.2
-scikit-learn==1.9.0
-scipy==1.18.0
+scikit-learn==1.9.1
+scipy==1.18.1
 seaborn==0.13.2

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -4,26 +4,28 @@ attrs==26.1.0
     # via
     #   jsonschema
     #   referencing
-awscli @ git+https://github.com/aws/aws-cli@305c68ef3fa68a15cdd8f50d9e7077c0e1ff8877
+awscli @ git+https://github.com/aws/aws-cli@d73aa8eebeba125052d965aaff3f4c7901165990
     # via -r requirements-core.txt
-awscrt==0.35.0
+awscrt==0.36.2
     # via awscli
-boto3==1.43.46
+boto3==1.43.92
     # via -r requirements-core.txt
-botocore==1.43.46
+botocore==1.43.92
     # via
     #   boto3
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
-charset-normalizer==3.4.9
+charset-normalizer==3.5.1
     # via requests
-civis==2.9.1
+civis==2.10.0
     # via -r requirements-core.txt
-click==8.4.2
+click==8.5.0
     # via civis
 cloudpickle==3.1.2
-    # via civis
+    # via
+    #   civis
+    #   joblib
 colorama==0.4.6
     # via awscli
 contourpy==1.3.3
@@ -34,16 +36,16 @@ distro==1.8.0
     # via awscli
 docutils==0.19
     # via awscli
-fonttools==4.63.0
+fonttools==4.65.0
     # via matplotlib
-idna==3.18
+idna==3.19
     # via requests
 jmespath==1.0.1
     # via
     #   awscli
     #   boto3
     #   botocore
-joblib==1.5.3
+joblib==1.6.0
     # via
     #   civis
     #   scikit-learn
@@ -53,15 +55,15 @@ jsonschema==4.26.0
     # via civis
 jsonschema-specifications==2025.9.1
     # via jsonschema
-kiwisolver==1.5.0
+kiwisolver==1.5.1
     # via matplotlib
-matplotlib==3.11.0
+matplotlib==3.11.1
     # via
     #   -r requirements-core.txt
     #   seaborn
-narwhals==2.24.0
+narwhals==2.26.0
     # via scikit-learn
-numpy==2.5.1
+numpy==2.5.3
     # via
     #   -r requirements-core.txt
     #   contourpy
@@ -70,17 +72,17 @@ numpy==2.5.1
     #   scikit-learn
     #   scipy
     #   seaborn
-packaging==26.2
+packaging==26.3
     # via matplotlib
-pandas==3.0.3
+pandas==3.0.5
     # via
     #   -r requirements-core.txt
     #   seaborn
 pillow==12.3.0
     # via matplotlib
-polars==1.42.1
+polars==1.44.2
     # via -r requirements-core.txt
-polars-runtime-32==1.42.1
+polars-runtime-32==1.44.2
     # via polars
 prompt-toolkit==3.0.51
     # via awscli
@@ -110,11 +112,11 @@ ruamel-yaml==0.19.1
     # via awscli
 ruamel-yaml-clib==0.2.15
     # via awscli
-s3transfer==0.19.1
+s3transfer==0.19.2
     # via boto3
-scikit-learn==1.9.0
+scikit-learn==1.9.1
     # via -r requirements-core.txt
-scipy==1.18.0
+scipy==1.18.1
     # via
     #   -r requirements-core.txt
     #   scikit-learn


### PR DESCRIPTION
This pull request bumps civis-python to the latest 2.10.0. While we're at it, we're also bumping the versions of other core dependencies to their latest. There are no (known) breaking changes.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
