### PR TITLE
[CIVIS-13985] MAINT switch to GitHub Actions for autobuilds

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,0 +1,42 @@
+name: Build and test image
+
+# Reusable gate shared by release.yaml and latest.yaml, so neither can publish an
+# image that fails the test suite. This workflow never sees the Docker Hub
+# credentials: `workflow_call` below declares no `secrets:`, and neither caller
+# passes `secrets:` or `secrets: inherit`.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      # The publishing jobs reuse this cache to avoid rebuilding from scratch.
+      # `scope` isolates it from any other build in the repo; `mode=max` also
+      # caches stages that aren't part of the exported image. `ignore-error` keeps
+      # a flaky cache export -- this image is several GB -- from failing the gate
+      # and thereby blocking a publish, since the cache is only an optimization.
+      - name: Build the test image
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          target: test
+          load: true
+          push: false
+          tags: ds-python:test
+          cache-from: type=gha,scope=ds-python
+          cache-to: type=gha,scope=ds-python,mode=max,ignore-error=true
+
+      - name: Run the image test suite
+        run: docker run --rm ds-python:test /test_image.py -vv

--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -1,0 +1,64 @@
+name: Publish latest to Docker Hub
+
+# Publishes the `latest` Docker Hub tag on every merge to master. Replaces Docker
+# Hub's Automated Builds, which retires on 2027-04-01:
+# https://docs.docker.com/docker-hub/repos/manage/builds/migrate/
+#
+# Version tags are published separately, by release.yaml.
+#
+# Automated Builds also overwrote the Docker Hub repository description with this
+# repo's README.md. That isn't reproduced here: it needs a Docker Hub credential
+# with repository Admin, and OIDC issues registry tokens only. The Docker Hub
+# description is now maintained by hand -- see the README's maintainer section.
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+# Back-to-back merges must not publish an older commit's build as `latest`.
+# Cancelling a push mid-flight is safe: a registry tag only moves on the final
+# manifest PUT, once every layer has finished uploading.
+concurrency:
+  group: dockerhub-latest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    uses: ./.github/workflows/build-test.yaml
+
+  push:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: dockerhub-publish
+       id-token: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      # See release.yaml for how this keyless OIDC login works.
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4.6.0
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
+        with:
+          username: civisanalytics
+
+      # See release.yaml for why provenance, sbom, and platforms are set this way.
+      - name: Build and push
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          target: production
+          push: true
+          tags: civisanalytics/datascience-python:latest
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=ds-python

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,115 @@
+name: Publish release to Docker Hub
+
+# Publishes the versioned Docker Hub tags for a release: "major", "major.minor",
+# and "major.minor.micro". Replaces Docker Hub's Automated Builds, which is
+# deprecated and retires on 2027-04-01:
+# https://docs.docker.com/docker-hub/repos/manage/builds/migrate/
+#
+# The trigger is the tag push, which is what publishing a GitHub release creates.
+# It also matches how Automated Builds worked -- its build rules matched on tags.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+# Two releases must not publish at once: they both move the "major" and
+# "major.minor" tags, so interleaved pushes could leave "9" pointing at the older
+# of them. One group for all releases serializes them, and a re-run queues behind
+# an in-flight publish rather than cancelling it.
+concurrency:
+  group: dockerhub-release
+  cancel-in-progress: false
+
+jobs:
+  # test_image.py checks VERSION against CHANGELOG.md, but nothing checks either
+  # one against the tag being released. Without this, tagging v9.0.1 after
+  # forgetting the Dockerfile bump publishes an image labelled 9.0.0. This runs
+  # ahead of the build so a mistyped tag fails in seconds rather than after a
+  # full image build and test run.
+  check-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Check the Dockerfile version matches the tag
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          dockerfile_version="$(
+            grep -m1 '^ENV VERSION=' Dockerfile \
+              | sed -E 's/^ENV VERSION=([0-9]+\.[0-9]+\.[0-9]+).*/\1/'
+          )"
+          if [ "${tag_version}" != "${dockerfile_version}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} is version ${tag_version}, but the Dockerfile sets VERSION=${dockerfile_version}. Bump VERSION, VERSION_MAJOR, VERSION_MINOR, and VERSION_MICRO in the Dockerfile before tagging a release."
+            exit 1
+          fi
+          echo "Dockerfile VERSION=${dockerfile_version} matches tag ${GITHUB_REF_NAME}."
+
+  test:
+    needs: check-version
+    uses: ./.github/workflows/build-test.yaml
+
+  push:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: dockerhub-publish
+    permissions:
+      contents: read
+      # Lets the job request a GitHub OIDC token, which Docker Hub exchanges for a
+      # short-lived registry token. Required for the keyless login below.
+      id-token: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7.0.1
+
+      # `latest=false` is required. The default (latest=auto) would add a `latest`
+      # tag to this push, racing latest.yaml, which owns `latest` on merges to master.
+      - name: Derive the Docker Hub tags
+        id: meta
+        uses: docker/metadata-action@v6.2.0
+        with:
+          images: civisanalytics/datascience-python
+          flavor: latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      # Keyless login over OIDC -- no stored Docker Hub token. login-action
+      # exchanges this run's GitHub OIDC token for a Docker Hub token that expires
+      # in minutes and can't be reused. `password` is deliberately omitted; setting
+      # it would switch the action back to static-credential mode. The connection
+      # ID is not a secret, so it lives in a repository variable.
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4.6.0
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
+        with:
+          username: civisanalytics
+
+      # provenance and sbom are off so we keep publishing a plain single-platform
+      # manifest. Buildx otherwise attaches attestations, which turn the push into
+      # a multi-manifest image index -- a shape some clients that pull this image
+      # can't handle, and not what Automated Builds produced.
+      #
+      # `platforms` is intentionally unset: the Dockerfile already pins the platform
+      # via its own ARG PLATFORM, and a second mechanism could disagree with it.
+      - name: Build and push
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          target: production
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          provenance: false
+          sbom: false
+          cache-from: type=gha,scope=ds-python

--- a/README.md
+++ b/README.md
@@ -95,14 +95,34 @@ and describe any changes in the [change log](CHANGELOG.md).
 
 ## For Maintainers
 
-This repo has autobuild enabled. Any PR that is merged to master will
-be built as the `latest` tag on DockerHub.
-Once you are ready to create a new version, go to the "releases" tab of the repository and click
-"Draft a new release". GitHub will prompt you to create a new tag, release title, and release
-description. The tag should use semantic versioning in the form "vX.X.X"; "major.minor.micro".
-The title of the release should be the same as the tag. Include a change log in the release description.
-Once the release is tagged, DockerHub will automatically build three identical containers, with labels
-"major", "major.minor", and "major.minor.micro".
+Publishing to DockerHub is handled by GitHub Actions
+(see [.github/workflows](.github/workflows)). Both publishing workflows build the
+image and run the test suite before they push anything.
+
+There is no stored DockerHub password or access token. The workflows authenticate
+over OIDC: each run exchanges a GitHub identity token for a DockerHub token that
+expires within minutes. This requires two things a repository admin must set up
+once -- an OIDC connection on the `civisanalytics` DockerHub organization, and a
+`DOCKERHUB_OIDC_CONNECTIONID` repository variable holding that connection's ID
+(it is an identifier, not a secret). The publishing jobs also run in a
+`dockerhub-publish` environment restricted to `master` and `v*.*.*`.
+
+Any PR merged to master is published as the `latest` tag on DockerHub.
+
+To cut a new version:
+
+1. Bump `VERSION`, `VERSION_MAJOR`, `VERSION_MINOR`, and `VERSION_MICRO`
+   in the [Dockerfile](Dockerfile), and move the `Unreleased` section of the
+   [change log](CHANGELOG.md) under a `[major.minor.micro]` heading. Do this
+   *before* tagging -- the release workflow refuses to publish if the Dockerfile's
+   `VERSION` doesn't match the tag.
+2. Once that is merged, go to the "releases" tab of the repository and click
+   "Draft a new release". GitHub will prompt you to create a new tag, release title, and release
+   description. The tag must use semantic versioning in the form "vX.X.X"; "major.minor.micro".
+   The leading "v" is required -- tags without it won't trigger a build.
+   The title of the release should be the same as the tag. Include a change log in the release description.
+3. Publishing the release creates the tag, which builds and pushes three identical
+   containers labelled "major", "major.minor", and "major.minor.micro".
 
 # License
 


### PR DESCRIPTION
DockerHub is removing the autobuild feature in April 2027 (https://docs.docker.com/docker-hub/repos/manage/builds/migrate/). Based on the migration guide, a recommended approach is to switch to GitHub Actions for building and pushing new images to DockerHub. This PR implements autobuilds via GitHub Actions, matching the current "latest" and the major + major.minor + major.minor.patch tags.

I've already worked with IT to configure both the DockerHub and GitHub repos for "datascience-python", for the necessary ODIC-based setup. Here's the plan:

* Once this PR is merged into the master branch, the GitHub Actions workflow defined in `.github/workflows/latest.yaml` should run. Confirm from its run logs that everything works as expected. The logs will be our best record for verifying if the new setup has been done correctly or not. I haven't asked IT to remove the autobuild config on DockerHub yet, so the new "latest" image may be ambiguous between being built by DockerHub's autobuild or this new GitHub Actions workflow -- to to be resolved in the next step.
* Assuming everything looks good from the previous step, I'll then ask IT to remove the autobuild config on DockerHub.
* Then I'll file another PR for a new tag (v9.1.1) to update both Dockerfile and CHANGELOG.md.
* After this PR is merged, make a new GitHub release. The new tag v9.1.1 should trigger the GitHub Actions workflow defined in `.github/workflows/release.yaml`. If everything works correctly in this workflow, we should see new tags 9, 9.1, and 9.1.1 available on the DockerHub repo.

---

- [x] (For Civis employees only) Reference to a relevant ticket in the pull request title
- [x] Changelog entry added to `CHANGELOG.md` at the repo's root level
- [x] Description of change in the pull request description
- [x] If applicable, unit tests have been added and/or updated
- [x] The CircleCI builds have all passed
